### PR TITLE
Users/mitokic/hierarchical reconciliation bug

### DIFF
--- a/R/forecast_time_series.R
+++ b/R/forecast_time_series.R
@@ -559,6 +559,9 @@ forecast_time_series <- function(input_data,
                          frequency_number, 
                          return = "hts_gts")
     
+    print(hts_gts)
+    print(unique(model_test_date$Model_Test_Date))
+    
     hts_gts_df <- hts_gts %>%
       hts::allts() %>%
       data.frame() %>%
@@ -595,11 +598,11 @@ forecast_time_series <- function(input_data,
             as.matrix()
           
           if(forecast_approach == "standard_hierarchy") {
-            ts_combined <- data.frame(hts::combinef(ts, nodes = get_nodes(hts_gts), weights = (1/colMeans(temp_residuals^2, na.rm = TRUE)), 
+            ts_combined <- data.frame(hts::combinef(ts, nodes = hts::get_nodes(hts_gts), weights = (1/colMeans(temp_residuals^2, na.rm = TRUE)), 
                                                     keep ="bottom", nonnegative = !negative_fcst))
             colnames(ts_combined) <- colnames(data_ts)
           } else if(forecast_approach == "grouped_hierarchy") {
-            ts_combined <- data.frame(hts::combinef(ts, groups = get_groups(hts_gts), weights = (1/colMeans(temp_residuals^2, na.rm = TRUE)), 
+            ts_combined <- data.frame(hts::combinef(ts, groups = hts::get_groups(hts_gts), weights = (1/colMeans(temp_residuals^2, na.rm = TRUE)), 
                                                     keep ="bottom", nonnegative = !negative_fcst))
             colnames(ts_combined) <- colnames(data_ts)
           }

--- a/R/forecast_time_series.R
+++ b/R/forecast_time_series.R
@@ -478,15 +478,10 @@ forecast_time_series <- function(input_data,
   if(target_log_transformation) {
     
     fcst_final <- fcst_combination_final %>%
-      #dplyr::filter(Model %in% unique(c(fcst$Model, accuracy_final$Model))) %>%
       dplyr::mutate(Target = expm1(Target), 
                     FCST = expm1(FCST))
     
-    # resamples_tscv_final <- resamples_tscv %>%
-    #   dplyr::mutate(Target = expm1(Target))
-    
     back_test_initial_final <- back_test_initial %>%
-      #dplyr::filter(Model %in% unique(c(fcst$Model, accuracy_final$Model))) %>%
       dplyr::mutate(Target = expm1(Target), 
                     FCST = expm1(FCST))
     

--- a/R/forecast_time_series.R
+++ b/R/forecast_time_series.R
@@ -511,7 +511,7 @@ forecast_time_series <- function(input_data,
           dplyr::filter(Model %in% unique(fcst$Model)))
     
     back_test_unreconciled <- back_test_initial_final %>%
-      left_join(accuracy_final %>%
+      dplyr::left_join(accuracy_final %>%
                   dplyr::select(Combo, Model, Best_Model)) %>%
       dplyr::filter(Best_Model == "Yes") %>%
       dplyr::mutate(Model = "Best_Model") %>%

--- a/R/forecast_time_series.R
+++ b/R/forecast_time_series.R
@@ -549,7 +549,7 @@ forecast_time_series <- function(input_data,
     }
     
     #get hierarchical ts info
-    hts_gts <- data_tbl %>% 
+    hts_gts_list <- data_tbl %>% 
       get_modelling_ready_tbl(external_regressors,
                               hist_end_date,
                               combo_cleanup_date,
@@ -559,10 +559,7 @@ forecast_time_series <- function(input_data,
                          frequency_number, 
                          return = "hts_gts")
     
-    print(hts_gts)
-    print(unique(model_test_date$Model_Test_Date))
-    
-    hts_gts_df <- hts_gts %>%
+    hts_gts_df <- hts_gts_list$hts_gts %>%
       hts::allts() %>%
       data.frame()
     
@@ -598,13 +595,13 @@ forecast_time_series <- function(input_data,
             as.matrix()
           
           if(forecast_approach == "standard_hierarchy") {
-            ts_combined <- data.frame(hts::combinef(ts, nodes = hts::get_nodes(hts_gts), weights = (1/colMeans(temp_residuals^2, na.rm = TRUE)), 
+            ts_combined <- data.frame(hts::combinef(ts, nodes = hts::get_nodes(hts_gts_list$hts_gts), weights = (1/colMeans(temp_residuals^2, na.rm = TRUE)), 
                                                     keep ="bottom", nonnegative = !negative_fcst))
-            colnames(ts_combined) <- colnames(data_ts)
+            colnames(ts_combined) <- colnames(hts_gts_list$data_ts)
           } else if(forecast_approach == "grouped_hierarchy") {
-            ts_combined <- data.frame(hts::combinef(ts, groups = hts::get_groups(hts_gts), weights = (1/colMeans(temp_residuals^2, na.rm = TRUE)), 
+            ts_combined <- data.frame(hts::combinef(ts, groups = hts::get_groups(hts_gts_list$hts_gts), weights = (1/colMeans(temp_residuals^2, na.rm = TRUE)), 
                                                     keep ="bottom", nonnegative = !negative_fcst))
-            colnames(ts_combined) <- colnames(data_ts)
+            colnames(ts_combined) <- colnames(hts_gts_list$data_ts)
           }
           
           hts_final <- cbind(Date, ts_combined) %>%

--- a/R/forecast_time_series.R
+++ b/R/forecast_time_series.R
@@ -563,7 +563,7 @@ forecast_time_series <- function(input_data,
       get_data_tbl_final(combo_variables,
                          forecast_approach,
                          frequency_number, 
-                         return = "hts_gts")
+                         return_type = "hts_gts")
     
     hts_gts_df <- hts_gts_list$hts_gts %>%
       hts::allts() %>%

--- a/R/forecast_time_series.R
+++ b/R/forecast_time_series.R
@@ -548,6 +548,22 @@ forecast_time_series <- function(input_data,
       
     }
     
+    #get hierarchical ts info
+    hts_gts <- data_tbl %>% 
+      get_modelling_ready_tbl(external_regressors,
+                              hist_end_date,
+                              combo_cleanup_date,
+                              combo_variables) %>%  
+      get_data_tbl_final(combo_variables,
+                         forecast_approach,
+                         frequency_number, 
+                         return = "hts_gts")
+    
+    hts_gts_df <- hts_gts %>%
+      hts::allts() %>%
+      data.frame() %>%
+    
+    #reconcile forecasts
     for(value in unique(model_test_date$Model_Test_Date)) {
       
       tryCatch(

--- a/R/forecast_time_series.R
+++ b/R/forecast_time_series.R
@@ -564,7 +564,7 @@ forecast_time_series <- function(input_data,
     
     hts_gts_df <- hts_gts %>%
       hts::allts() %>%
-      data.frame() %>%
+      data.frame()
     
     #reconcile forecasts
     for(value in unique(model_test_date$Model_Test_Date)) {

--- a/R/forecast_time_series.R
+++ b/R/forecast_time_series.R
@@ -501,7 +501,7 @@ forecast_time_series <- function(input_data,
     
     #extract best model and append to dataset
     fcst_unreconciled <- fcst_final %>%
-      left_join(accuracy_final %>%
+      dplyr::left_join(accuracy_final %>%
                   dplyr::select(Combo, Model, Best_Model)) %>%
       dplyr::filter(Best_Model == "Yes") %>%
       dplyr::mutate(Model = "Best_Model") %>%
@@ -608,7 +608,6 @@ forecast_time_series <- function(input_data,
                          dplyr::select(Combo, Date, Target)) %>%
       dplyr::mutate(FCST = ifelse(is.na(FCST) | is.nan(FCST), 0, FCST),
                     Target = ifelse(is.na(Target) | is.nan(Target), 0, Target)) %>%
-      #dplyr::left_join(accuracy_final) %>%
       dplyr::mutate(MAPE = abs((Target-FCST)/Target)) %>%
       dplyr::group_by(Combo, .id, Model) %>%
       dplyr::mutate(Horizon = dplyr::row_number()) %>%

--- a/R/forecast_time_series.R
+++ b/R/forecast_time_series.R
@@ -568,7 +568,7 @@ forecast_time_series <- function(input_data,
     
     #reconcile forecasts
     for(value in unique(model_test_date$Model_Test_Date)) {
-      
+      print(value)
       tryCatch(
         expr = {
           

--- a/R/forecast_time_series.R
+++ b/R/forecast_time_series.R
@@ -504,7 +504,7 @@ forecast_time_series <- function(input_data,
       dplyr::left_join(accuracy_final %>%
                   dplyr::select(Combo, Model, Best_Model)) %>%
       dplyr::filter(Best_Model == "Yes") %>%
-      dplyr::mutate(Model = "Best_Model") %>%
+      dplyr::mutate(Model = "Best-Model") %>%
       dplyr::select(-Best_Model) %>%
       rbind(
         fcst_final %>%
@@ -514,7 +514,7 @@ forecast_time_series <- function(input_data,
       dplyr::left_join(accuracy_final %>%
                   dplyr::select(Combo, Model, Best_Model)) %>%
       dplyr::filter(Best_Model == "Yes") %>%
-      dplyr::mutate(Model = "Best_Model") %>%
+      dplyr::mutate(Model = "Best-Model") %>%
       dplyr::select(-Best_Model) %>%
       rbind(back_test_initial_final)
     
@@ -565,7 +565,7 @@ forecast_time_series <- function(input_data,
     
     #reconcile forecasts
     for(value in unique(model_test_date$Model_Test_Date)) {
-      print(value)
+
       tryCatch(
         expr = {
           
@@ -692,7 +692,7 @@ forecast_time_series <- function(input_data,
                     lo.95 = FCST - (1.96*Residual_Std_Dev), 
                     hi.80 = FCST + (1.28*Residual_Std_Dev), 
                     hi.95 = FCST + (1.96*Residual_Std_Dev)) %>%
-      dplyr::mutate(Model = "Best Model") %>%
+      dplyr::mutate(Model = "Best-Model") %>%
       dplyr::select(Combo, Date, Model, FCST, lo.95, lo.80, hi.80, hi.95)
     
     future_fcst_final <- fcst_final %>%

--- a/R/forecast_time_series.R
+++ b/R/forecast_time_series.R
@@ -597,6 +597,7 @@ forecast_time_series <- function(input_data,
           
         },
         error = function(e){ 
+          print(e)
           print('skipping')
         }
       )

--- a/R/forecast_time_series.R
+++ b/R/forecast_time_series.R
@@ -120,12 +120,12 @@ forecast_time_series <- function(input_data,
   weekly_to_daily = TRUE
 ) {
 
-  # 1. Load Evironment Info:
+  # 1. Load Evironment Info: ----
   
   load_env_info(reticulate_environment)
   
   
-  # 2. Initial Unit Tests:
+  # 2. Initial Unit Tests: ----
   hist_dt <- validate_forecasting_inputs(input_data,
                                          combo_variables,
                                          target_variable,
@@ -150,40 +150,46 @@ forecast_time_series <- function(input_data,
   hist_end_date <- hist_dt$hist_end_date
   
   
-  # 3. Update Input Values:
+  # 3. Update Input Values: ----
   
-  #Select fourier values ----
+  # * Select fourier values ----
   fourier_periods <- get_fourier_periods(fourier_periods,
                                          date_type)
-  #Select lag values ----
+  # * Select lag values ----
   lag_periods <- get_lag_periods(lag_periods, 
                                  date_type,
                                  forecast_horizon)
   
-  #Select rolling window values ----
+  # * Select rolling window values ----
   rolling_window_periods <- get_rolling_window_periods(rolling_window_periods,
                                                        date_type)
   
-  #Missing values ----
+  # * Missing values ----
   pad_value <- ifelse(clean_missing_values,NA,0)
   
-  #Frequency number (year, quarter, month, etc) ----
+  # * Frequency number (year, quarter, month, etc) ----
   frequency_number <- get_frequency_number(date_type)
   
-  #TS frequency (year, quarter, month, etc) ----
+  # * TS frequency (year, quarter, month, etc) ----
   gluon_ts_frequency <- get_gluon_ts_frequency(date_type)
   
-  #Seasonal_periods (year, quarter, month, etc) ----
+  # * Seasonal_periods (year, quarter, month, etc) ----
   seasonal_periods <- get_seasonal_periods(date_type)
   
-  #Frequency number (year, quarter, month, etc) ----
+  # * Frequency number (year, quarter, month, etc) ----
   date_regex <- get_date_regex(date_type)
   
-  # * back test spacing ----
+  # * Back Test Spacing ----
   back_test_spacing <- get_back_test_spacing(back_test_spacing,
                                              date_type)
   
-  # 4. Prep Data:
+  # * Yearly Forecast Adjustment ----
+  if(date_type =="year") {
+    run_ensemble_models = FALSE
+    warning("ensemble models have been turned off for yearly forecasts")
+  }
+  
+  # 4. Prep Data ----
   
   cli::cli_h1("Prepping Data")
   

--- a/R/multivariate_data_prep.R
+++ b/R/multivariate_data_prep.R
@@ -8,6 +8,7 @@
 #' @param rolling_window_periods list of periods when building rolling window features
 #' 
 #' @return feature engineered data to input into models
+#' @noRd
 multivariate_prep_recipe_1 <- function(data, external_regressors, xregs_future_values_list, fourier_periods, 
                                        lag_periods, rolling_window_periods) {
   
@@ -138,6 +139,7 @@ multivariate_prep_recipe_1 <- function(data, external_regressors, xregs_future_v
 #' @param forecast_horizon forecast horizon
 #' 
 #' @return feature engineered data to input into models
+#' @noRd
 multivariate_prep_recipe_2 <- function(data, external_regressors, xregs_future_values_list, 
                                        fourier_periods, lag_periods, rolling_window_periods, 
                                        date_type, forecast_horizon) {

--- a/R/prepare_hierarchy_data.R
+++ b/R/prepare_hierarchy_data.R
@@ -130,7 +130,8 @@ get_data_tbl_final <- function(data_tbl,
       
       Date = data_cast$Date
       
-      if(return == "data") {
+      
+      if(return == "data") { # return historical hierarchical data as tibble for modeling
         
         data_cast %>%
           dplyr::select(-Date) %>%
@@ -145,7 +146,7 @@ get_data_tbl_final <- function(data_tbl,
                               values_to = "Target") %>%
           tibble::tibble()
         
-      } else if(return == "hts_gts") {
+      } else if(return == "hts_gts") { # return a list of hierarchical info used when reconciling
         data_ts <- data_cast %>%
           dplyr::select(-Date) %>%
           ts(frequency = frequency_number)

--- a/R/prepare_hierarchy_data.R
+++ b/R/prepare_hierarchy_data.R
@@ -109,7 +109,7 @@ get_data_tbl_final <- function(data_tbl,
   }
   
   # return correct hts info
-  data_hts_return <- function(df,ret_obj){
+  data_hts_return <- function(df,ret_obj, hts_list){
     if(ret_obj == "data"){
       
       Date = df$Date
@@ -117,7 +117,7 @@ get_data_tbl_final <- function(data_tbl,
       df %>%
         dplyr::select(-Date) %>%
         ts(frequency = frequency_number)%>% 
-        get_hts(some_list)  %>%
+        get_hts(hts_list)  %>%
         hts::allts() %>%
         data.frame() %>%
         tibble::add_column(Date = Date,
@@ -132,7 +132,7 @@ get_data_tbl_final <- function(data_tbl,
         ts(frequency = frequency_number)
       
       hts_gts <- data_ts %>%
-        get_hts(some_list)
+        get_hts(hts_list)
       
       return(list(data_ts = data_ts, hts_gts = hts_gts))
     } else{
@@ -162,7 +162,7 @@ get_data_tbl_final <- function(data_tbl,
                            values_from = Target)
       
       data_cast %>%
-        data_hts_return(ret_obj = return_type)
+        data_hts_return(ret_obj = return_type, hts_list = some_list)
       
     }
     

--- a/R/prepare_hierarchy_data.R
+++ b/R/prepare_hierarchy_data.R
@@ -162,7 +162,7 @@ get_data_tbl_final <- function(data_tbl,
                            values_from = Target)
       
       data_cast %>%
-        data_hts_return(return_obj = return_type)
+        data_hts_return(ret_obj = return_type)
       
     }
     

--- a/R/prepare_hierarchy_data.R
+++ b/R/prepare_hierarchy_data.R
@@ -4,13 +4,15 @@
 #' @param combo_variables list of combo variables
 #' @param forecast_approach forecasting approach
 #' @param frequency_number frequency number 
+#' @param return return data or hierarchical ts object
 #' 
 #' @return data_tbl_final
 #' @noRd
 get_data_tbl_final <- function(data_tbl,
                           combo_variables,
                           forecast_approach,
-                          frequency_number){
+                          frequency_number, 
+                          return = "data"){
   
   # Group List for Grouped Hierarchy
   get_group_list <- function(data_hts_gts_df){
@@ -107,7 +109,7 @@ get_data_tbl_final <- function(data_tbl,
   }
   
   # main data table function to produce our table
-  data_tbl_func <- function(df){
+  data_tbl_func <- function(df, return="data"){
     
     if(forecast_approach == 'bottoms_up'){
       df
@@ -128,7 +130,7 @@ get_data_tbl_final <- function(data_tbl,
       
       Date = data_cast$Date
       
-      data_cast %>%
+      final_output <- data_cast %>%
         dplyr::select(-Date) %>%
         ts(frequency = frequency_number)%>% 
         get_hts(some_list)  %>%
@@ -140,11 +142,25 @@ get_data_tbl_final <- function(data_tbl,
                           names_to = "Combo", 
                           values_to = "Target") %>%
         tibble::tibble()
+      
+      hts_gts <- data_cast %>%
+        dplyr::select(-Date) %>%
+        ts(frequency = frequency_number)%>% 
+        get_hts(some_list)
+      
+      if(return == "data") {
+        
+        return(final_output)
+        
+      } else if(return == "hts_gts") {
+        return(hts_gts)
+      }
+      
     }
     
   }
   
-  data_tbl %>% data_tbl_func
+  data_tbl %>% data_tbl_func(return = return)
   
 }
 

--- a/R/prepare_hierarchy_data.R
+++ b/R/prepare_hierarchy_data.R
@@ -126,7 +126,7 @@ get_data_tbl_final <- function(data_tbl,
                             names_to = "Combo", 
                             values_to = "Target") %>%
         tibble::tibble()
-    } else if(return == "hts_gts") {
+    } else if(ret_obj == "hts_gts") {
       data_ts <- data_cast %>%
         dplyr::select(-Date) %>%
         ts(frequency = frequency_number)

--- a/R/prepare_hierarchy_data.R
+++ b/R/prepare_hierarchy_data.R
@@ -130,30 +130,30 @@ get_data_tbl_final <- function(data_tbl,
       
       Date = data_cast$Date
       
-      final_output <- data_cast %>%
-        dplyr::select(-Date) %>%
-        ts(frequency = frequency_number)%>% 
-        get_hts(some_list)  %>%
-        hts::allts() %>%
-        data.frame() %>%
-        tibble::add_column(Date = Date,
-                   .before = 1)%>%
-        tidyr::pivot_longer(!Date, 
-                          names_to = "Combo", 
-                          values_to = "Target") %>%
-        tibble::tibble()
-      
-      hts_gts <- data_cast %>%
-        dplyr::select(-Date) %>%
-        ts(frequency = frequency_number)%>% 
-        get_hts(some_list)
-      
       if(return == "data") {
         
-        return(final_output)
+        data_cast %>%
+          dplyr::select(-Date) %>%
+          ts(frequency = frequency_number)%>% 
+          get_hts(some_list)  %>%
+          hts::allts() %>%
+          data.frame() %>%
+          tibble::add_column(Date = Date,
+                             .before = 1)%>%
+          tidyr::pivot_longer(!Date, 
+                              names_to = "Combo", 
+                              values_to = "Target") %>%
+          tibble::tibble()
         
       } else if(return == "hts_gts") {
-        return(hts_gts)
+        data_ts <- data_cast %>%
+          dplyr::select(-Date) %>%
+          ts(frequency = frequency_number)
+        
+        hts_gts <- data_ts %>%
+          get_hts(some_list)
+        
+        return(list(data_ts = data_ts, hts_gts = hts_gts))
       }
       
     }

--- a/R/prepare_hierarchy_data.R
+++ b/R/prepare_hierarchy_data.R
@@ -127,7 +127,7 @@ get_data_tbl_final <- function(data_tbl,
                             values_to = "Target") %>%
         tibble::tibble()
     } else if(ret_obj == "hts_gts") {
-      data_ts <- data_cast %>%
+      data_ts <- df %>%
         dplyr::select(-Date) %>%
         ts(frequency = frequency_number)
       

--- a/R/prepare_hierarchy_data.R
+++ b/R/prepare_hierarchy_data.R
@@ -134,7 +134,7 @@ get_data_tbl_final <- function(data_tbl,
         get_hts(some_list)  %>%
         hts::allts() %>%
         data.frame() %>%
-        add_column(Date = Date,
+        tibble::add_column(Date = Date,
                    .before = 1)%>%
         tidyr::pivot_longer(!Date, 
                           names_to = "Combo", 


### PR DESCRIPTION
- fixed bug for standard and grouped hierarchical forecasts
- changed the best model output name from "Best Model" to "Best-Model" to follow similar formatting as other models
- automatically turned ensemble models off for yearly forecasts. In order to prevent multiple errors when building ensemble training data. Could be something to come back to and build a more robust solution going forward. 