### PR TITLE
Users/mitokic/number cores feature

### DIFF
--- a/R/configure_forecast_run.R
+++ b/R/configure_forecast_run.R
@@ -265,6 +265,6 @@ get_transfer_functions <- function(){
     "invoke_forecast_function", "get_recipie_simple", "get_workflow_simple", "get_fit_simple", "get_freq_adjustment",
     "get_recipie_configurable", "get_fit_wkflw_nocombo", "get_latin_hypercube_grid", "get_resample_tune_grid", 
     "get_resample_tscv", "get_tune_grid", "get_not_all_data_models", "get_export_packages", "get_fit_wkflw_best",
-    "get_kfold_tune_grid", "get_resample_kfold", "init_parallel_within","exit_parallel_within")
+    "get_kfold_tune_grid", "get_resample_kfold", "init_parallel_within","exit_parallel_within", "get_cores")
 }
 

--- a/R/forecast_models.R
+++ b/R/forecast_models.R
@@ -209,6 +209,7 @@ invoke_forecast_function <- function(fn_to_invoke,
 #' @param forecast_horizon Forecast Horizon
 #' @param run_model_parallel Run Model in Parallel
 #' @param parallel_processing Which parallel processing to use
+#' @param num_cores number of cores for parallel processing
 #' @param run_deep_learning Run Deep Learning model
 #' @param frequency_number Frequency Number
 #' @param models_to_run Models to Run
@@ -235,6 +236,7 @@ construct_forecast_models <- function(full_data_tbl,
                                       forecast_horizon,
                                       run_model_parallel,
                                       parallel_processing,
+                                      num_cores,
                                       run_deep_learning,
                                       frequency_number,
                                       models_to_run,
@@ -317,7 +319,7 @@ construct_forecast_models <- function(full_data_tbl,
 
     # parallel processing
     if(run_model_parallel==TRUE & parallel_processing!="local_machine") {
-      parallel_args <- init_parallel_within(parallel_processing)
+      parallel_args <- init_parallel_within(parallel_processing, num_cores)
     }
 
     cli::cli_h3("Individual Model Training")

--- a/R/forecast_time_series.R
+++ b/R/forecast_time_series.R
@@ -38,6 +38,8 @@
 #'   runs time series in parallel on a remote compute cluster in Azure Batch. 
 #' @param run_model_parallel Run model training in parallel, only works when parallel_processing is set to 
 #'   'local_machine' or 'azure_batch'.
+#' @param num_cores Number of cores to run when parallel processing is set up. Used when running parallel computations 
+#'   on local machine or within Azure. Can't be greater than number of cores on machine.
 #' @param azure_batch_credentials Credentials to run parallel_processing in Azure Batch.
 #' @param azure_batch_cluster_config Compute cluster specification to run parallel_processing in Azure Batch.
 #' @param azure_batch_cluster_delete Delete the Azure Batch compute cluster after Finn finished running. 
@@ -100,6 +102,7 @@ forecast_time_series <- function(input_data,
   forecast_approach = "bottoms_up",
   parallel_processing = 'none',
   run_model_parallel = TRUE,
+  num_cores = NULL,
   azure_batch_credentials = NULL, 
   azure_batch_cluster_config = NULL, 
   azure_batch_cluster_delete = FALSE, 
@@ -144,7 +147,9 @@ forecast_time_series <- function(input_data,
                                          forecast_approach,
                                          parallel_processing,
                                          run_model_parallel,
+                                         num_cores,
                                          azure_batch_credentials,
+                                         azure_batch_cluster_config,
                                          max_model_average)
   hist_start_date <- hist_dt$hist_start_date
   hist_end_date <- hist_dt$hist_end_date
@@ -250,6 +255,7 @@ forecast_time_series <- function(input_data,
                                                forecast_horizon,
                                                run_model_parallel,
                                                parallel_processing,
+                                               num_cores,
                                                run_deep_learning,
                                                frequency_number,
                                                models_to_run,
@@ -287,7 +293,8 @@ forecast_time_series <- function(input_data,
   if(parallel_processing=="local_machine") {
     
    fcst <- get_fcast_parallel(combo_list,
-                              forecast_models_fn)
+                              forecast_models_fn, 
+                              num_cores)
     
   }
   

--- a/R/forecast_time_series.R
+++ b/R/forecast_time_series.R
@@ -355,7 +355,7 @@ forecast_time_series <- function(input_data,
         combinations_tbl <-  foreach::foreach(i = model_combinations[[1]], .combine = 'rbind', 
                                               .packages = c('rlist', 'tidyverse', 'lubridate', 
                                                             "doParallel", "parallel", "gtools"), 
-                                              .export = c("fcst_prep")) %dopar% {
+                                              .export = c("fcst_prep", "get_cores")) %dopar% {
                                                 
                                                 fcst_combination_temp <- fcst_prep %>%
                                                   dplyr::filter(Model %in% strsplit(i, split = "_")[[1]]) %>%
@@ -409,7 +409,7 @@ forecast_time_series <- function(input_data,
       
       combinations_tbl_final <- foreach(i = 2:min(max_model_average, length(model_list)), .combine = 'rbind',
                                         .packages = get_export_packages(), 
-                                        .export = c("fcst_prep")) %dopar% {create_model_averages(i)}
+                                        .export = c("fcst_prep", "get_cores")) %dopar% {create_model_averages(i)}
       
       parallel::stopCluster(cl)
       
@@ -421,7 +421,7 @@ forecast_time_series <- function(input_data,
       
       combinations_tbl_final <- foreach(i = 2:min(max_model_average, length(model_list)), .combine = 'rbind',
                                         .packages = get_export_packages(), 
-                                        .export = c("fcst_prep"),
+                                        .export = c("fcst_prep", "get_cores"),
                                         .options.azure = list(maxTaskRetryCount = 0, autoDeleteJob = TRUE, 
                                                               job = substr(paste0('finn-model-avg-combo-', strftime(Sys.time(), format="%H%M%S"), '-', 
                                                                                   tolower(gsub(" ", "-", trimws(gsub("\\s+", " ", gsub("[[:punct:]]", '', run_name)))))), 1, 63)),

--- a/R/forecast_time_series.R
+++ b/R/forecast_time_series.R
@@ -402,7 +402,13 @@ forecast_time_series <- function(input_data,
     # parallel run on local machine
     if(parallel_processing=="local_machine") {
       
-      cl <- parallel::makeCluster(parallel::detectCores())
+      if(is.null(num_cores)) {
+        cores <- parallel::detectCores()-1
+      } else {
+        cores <- min(num_cores, parallel::detectCores()-1)
+      }
+      
+      cl <- parallel::makeCluster(cores)
       doParallel::registerDoParallel(cl)
       
       combinations_tbl_final <- foreach(i = 2:min(max_model_average, length(model_list)), .combine = 'rbind',

--- a/R/forecast_time_series.R
+++ b/R/forecast_time_series.R
@@ -343,7 +343,7 @@ forecast_time_series <- function(input_data,
       #parallel processing
       if(run_model_parallel==TRUE & parallel_processing!="local_machine") {
         
-        cores <- parallel::detectCores()
+        cores <- get_cores(num_cores)
         cl <- parallel::makeCluster(cores)
         doParallel::registerDoParallel(cl)
         
@@ -402,11 +402,7 @@ forecast_time_series <- function(input_data,
     # parallel run on local machine
     if(parallel_processing=="local_machine") {
       
-      if(is.null(num_cores)) {
-        cores <- parallel::detectCores()-1
-      } else {
-        cores <- min(num_cores, parallel::detectCores()-1)
-      }
+      cores <- get_cores(num_cores)
       
       cl <- parallel::makeCluster(cores)
       doParallel::registerDoParallel(cl)

--- a/R/forecast_time_series.R
+++ b/R/forecast_time_series.R
@@ -39,7 +39,8 @@
 #' @param run_model_parallel Run model training in parallel, only works when parallel_processing is set to 
 #'   'local_machine' or 'azure_batch'.
 #' @param num_cores Number of cores to run when parallel processing is set up. Used when running parallel computations 
-#'   on local machine or within Azure. Can't be greater than number of cores on machine.
+#'   on local machine or within Azure. Default of NULL uses total amount of cores on machine minus one. Can't be greater 
+#'   than number of cores on machine minus 1.
 #' @param azure_batch_credentials Credentials to run parallel_processing in Azure Batch.
 #' @param azure_batch_cluster_config Compute cluster specification to run parallel_processing in Azure Batch.
 #' @param azure_batch_cluster_delete Delete the Azure Batch compute cluster after Finn finished running. 

--- a/R/general_parallel.R
+++ b/R/general_parallel.R
@@ -1,3 +1,16 @@
+#' Get number of cores to use when registering parallel back end
+#' 
+#' @param num_cores number of cores for parallel processing
+#' @noRd 
+get_cores <-function(num_cores){
+
+  if(is.null(num_cores)) {
+    parallel::detectCores()-1
+  } else {
+    min(num_cores, parallel::detectCores()-1)
+  }
+}
+
 #' Call back function within forecast for init
 #' 
 #' Sets the right configuration during init
@@ -9,11 +22,7 @@ init_parallel_within <-function(type, num_cores){
   
   cli::cli_h3("Creating Parallel Processing")
   
-  if(is.null(num_cores)) {
-    cores <- parallel::detectCores()-1
-  } else {
-    cores <- min(num_cores, parallel::detectCores()-1)
-  }
+  cores <- get_cores(num_cores)
   
   cl <- parallel::makeCluster(cores)
   doParallel::registerDoParallel(cl)
@@ -56,11 +65,7 @@ get_fcast_parallel<- function(combo_list,
   
   cli::cli_h2("Creating Parallel Processing")
   
-  if(is.null(num_cores)) {
-    cores <- parallel::detectCores()-1
-  } else {
-    cores <- min(num_cores, parallel::detectCores()-1)
-  }
+  cores <- get_cores(num_cores)
   
   cl <- parallel::makeCluster(cores)
   doParallel::registerDoParallel(cl)

--- a/R/general_parallel.R
+++ b/R/general_parallel.R
@@ -3,12 +3,18 @@
 #' Sets the right configuration during init
 #' 
 #' @param type Type of parallel processing being done
+#' @param num_cores number of cores for parallel processing
 #' @noRd 
-init_parallel_within <-function(type){
+init_parallel_within <-function(type, num_cores){
   
   cli::cli_h3("Creating Parallel Processing")
   
-  cores <- parallel::detectCores()-1
+  if(is.null(num_cores)) {
+    cores <- cores <- parallel::detectCores()-1
+  } else {
+    cores <- min(num_cores, parallel::detectCores()-1)
+  }
+  
   cl <- parallel::makeCluster(cores)
   doParallel::registerDoParallel(cl)
   
@@ -40,15 +46,21 @@ exit_parallel_within <-function(cl){
 #' 
 #' @param combo_list Combo List
 #' @param call_back_fn Call Back Function
+#' @param num_cores number of cores for parallel processing
 #' 
 #' @return Forecast Object
 #' @noRd
 get_fcast_parallel<- function(combo_list,
-                              call_back_fn){
+                              call_back_fn, 
+                              num_cores){
   
   cli::cli_h2("Creating Parallel Processing")
   
-  cores <- parallel::detectCores()-1
+  if(is.null(num_cores)) {
+    cores <- cores <- parallel::detectCores()-1
+  } else {
+    cores <- min(num_cores, parallel::detectCores()-1)
+  }
   
   cl <- parallel::makeCluster(cores)
   doParallel::registerDoParallel(cl)

--- a/R/general_parallel.R
+++ b/R/general_parallel.R
@@ -10,7 +10,7 @@ init_parallel_within <-function(type, num_cores){
   cli::cli_h3("Creating Parallel Processing")
   
   if(is.null(num_cores)) {
-    cores <- cores <- parallel::detectCores()-1
+    cores <- parallel::detectCores()-1
   } else {
     cores <- min(num_cores, parallel::detectCores()-1)
   }
@@ -57,7 +57,7 @@ get_fcast_parallel<- function(combo_list,
   cli::cli_h2("Creating Parallel Processing")
   
   if(is.null(num_cores)) {
-    cores <- cores <- parallel::detectCores()-1
+    cores <- parallel::detectCores()-1
   } else {
     cores <- min(num_cores, parallel::detectCores()-1)
   }

--- a/R/validate_forecasting_inputs.R
+++ b/R/validate_forecasting_inputs.R
@@ -192,7 +192,7 @@ validate_forecasting_inputs<-function(input_data,
   }
   
   #number of cores formatting
-  if(!is.numeric(num_cores) | !is.null(num_cores)) {
+  if(!is.numeric(num_cores) & !is.null(num_cores)) {
     stop("num_cores should be NULL or a numeric value")
   }
   

--- a/R/validate_forecasting_inputs.R
+++ b/R/validate_forecasting_inputs.R
@@ -21,8 +21,10 @@
 #' @param modeling_approach Currently only accuracy is supported
 #' @param forecast_approach Bottoms_up, grouped_hierarchy, standard_hierarchy
 #' @param parallel_processing azure_batch, local_machine, none
+#' @param num_cores number of cores for parallel processing
 #' @param run_model_parallel run hyperparameter search and model in parallel
 #' @param azure_batch_credentials Azure Batch Credentials 
+#' @param azure_batch_cluster_config Azure Batch Cluster Config
 #' @param max_model_average Maximum number of models to average
 #' 
 #' @return Returns hist_start_date and hist_end_date
@@ -45,7 +47,9 @@ validate_forecasting_inputs<-function(input_data,
                                       forecast_approach,
                                       parallel_processing,
                                       run_model_parallel,
+                                      num_cores,
                                       azure_batch_credentials,
+                                      azure_batch_cluster_config,
                                       max_model_average){
   
   retlist = list("hist_start_date" = hist_start_date,
@@ -187,9 +191,19 @@ validate_forecasting_inputs<-function(input_data,
     stop("parallel processing input must be one of these values: 'none', 'local_machine', 'azure_batch'")
   }
   
+  #number of cores formatting
+  if(!is.numeric(num_cores) | is.null(num_cores)) {
+    stop("num_cores should be NULL or a numeric value")
+  }
+  
   #check if azure credentials are given in case of parallel_processing = azure_batch
   if(parallel_processing == "azure_batch" & is.null(azure_batch_credentials)){
     stop("cannot run parallel_processing on azure_batch without batch credentials")
+  }
+  
+  #check if azure batch cluster info is given in case of parallel_processing = azure_batch
+  if(parallel_processing == "azure_batch" & is.null(azure_batch_cluster_config)){
+    stop("cannot run parallel_processing on azure_batch without cluster config")
   }
   
   #max model average formatting

--- a/R/validate_forecasting_inputs.R
+++ b/R/validate_forecasting_inputs.R
@@ -192,7 +192,7 @@ validate_forecasting_inputs<-function(input_data,
   }
   
   #number of cores formatting
-  if(!is.numeric(num_cores) | is.null(num_cores)) {
+  if(!is.numeric(num_cores) | !is.null(num_cores)) {
     stop("num_cores should be NULL or a numeric value")
   }
   


### PR DESCRIPTION
added feature that allows user to control number of cores that should be leveraged by parallel processes in Finn. If the user provides a number that is higher than the available cores on the machine (total cores minus 1) then it will default to leverage total cores minus 1 to prevent any errors. 