### PR TITLE
best model bug fix

### DIFF
--- a/R/forecast_time_series.R
+++ b/R/forecast_time_series.R
@@ -655,6 +655,7 @@ forecast_time_series <- function(input_data,
                     hi.80 = Target + (1.28*Residual_Std_Dev), 
                     hi.95 = Target + (1.96*Residual_Std_Dev)) %>%
       dplyr::select(-Residual_Std_Dev) %>%
+      dplyr::filter(!grepl('_', Model)) %>% # filter out model averages
       rbind(
         data_tbl %>%
           dplyr::mutate(Model = "NA") %>%
@@ -708,6 +709,7 @@ forecast_time_series <- function(input_data,
                     hi.80 = FCST + (1.28*Residual_Std_Dev), 
                     hi.95 = FCST + (1.96*Residual_Std_Dev)) %>%
       dplyr::select(-Residual_Std_Dev) %>%
+      dplyr::filter(!grepl('_', Model)) %>% # filter out model averages
       rbind(future_fcst_best_model) %>%
       dplyr::rename(Target = FCST) %>%
       tidyr::separate(Combo, into = combo_variables, sep = "--", remove = FALSE) %>%


### PR DESCRIPTION
fixed bug where duplicate values of best model show up in future forecast output. If the best model was a simple avg of multiple models, then a duplicate forecast value would result. 

For example for each date in the future you would see a model for "Best-Model" and "arima_ets" that contain the same forecast amount, when averaging arima and ets forecasts had the best accuracy during back testing. 

Fix was to filter out any simple model averages (model names that contain "_") in future forecast output. 