### PR TITLE
Users/mitokic/recipes control

### DIFF
--- a/R/forecast_models.R
+++ b/R/forecast_models.R
@@ -500,8 +500,8 @@ construct_forecast_models <- function(full_data_tbl,
           dplyr::select(-.id, -.key)
         
         rsplit_obj <- slice_tbl %>%
-          rsample::make_splits(ind = list(analysis = seq(nrow(train)),
-                                          assessment = nrow(train) + seq(nrow(test))),
+          rsample::make_splits(x = list(analysis = seq(nrow(train)),
+                                        assessment = nrow(train) + seq(nrow(test))),
                                class = "ts_cv_split")
         
         return(rsplit_obj)
@@ -698,8 +698,8 @@ construct_forecast_models <- function(full_data_tbl,
           dplyr::select(-.id, -.key)
         
         rsplit_obj <- slice_tbl %>%
-          rsample::make_splits(ind = list(analysis = seq(nrow(train)),
-                                          assessment = nrow(train) + seq(nrow(test))),
+          rsample::make_splits(x = list(analysis = seq(nrow(train)),
+                                        assessment = nrow(train) + seq(nrow(test))),
                                class = "ts_cv_split")
         
         return(rsplit_obj)

--- a/R/forecast_models.R
+++ b/R/forecast_models.R
@@ -277,7 +277,7 @@ construct_forecast_models <- function(full_data_tbl,
     # recipe 1: standard feature engineering
     run_data_full_recipe_1 <- NULL
     
-    if(is.null(recipes_to_run) | "R1" %in% recipes_to_run) {
+    if(is.null(recipes_to_run) | "R1" %in% recipes_to_run | sum(recipes_to_run == "all") == 1) {
       
       run_data_full_recipe_1 <- run_data_full_tbl %>%
         multivariate_prep_recipe_1(external_regressors = external_regressors,
@@ -297,8 +297,8 @@ construct_forecast_models <- function(full_data_tbl,
     
     # recipe 2: custom horizon specific feature engineering
     run_data_full_recipe_2 <- NULL
-    
-    if((is.null(recipes_to_run) | "R2" %in% recipes_to_run) & date_type %in% c("month", "quarter", "year")) {
+
+    if((is.null(recipes_to_run) & date_type %in% c("month", "quarter", "year")) | "R2" %in% recipes_to_run | sum(recipes_to_run == "all") == 1) {
       
       run_data_full_recipe_2 <- run_data_full_tbl %>%
         multivariate_prep_recipe_2(external_regressors = external_regressors,
@@ -385,7 +385,7 @@ construct_forecast_models <- function(full_data_tbl,
         
         freq_val <- frequency
         
-        if((model_name %in% r1_models) | (model_name %in% r2_models)){
+        if(((model_name %in% r1_models) | (model_name %in% r2_models)) & (is.null(recipes_to_run) | sum(recipes_to_run == "all") == 1 | "R1" %in% recipes_to_run)){
           
           add_name <- paste0(model_name,"-R1",model_name_suffix)
           if(model_name %in% deep_nn_models){
@@ -413,7 +413,7 @@ construct_forecast_models <- function(full_data_tbl,
               silent = TRUE)
         }
         
-        if(model_name %in% r2_models & ("R2" %in% recipes_to_run | (is.null(recipes_to_run) & date_type %in% c("month", "quarter", "year")))){
+        if(model_name %in% r2_models & ("R2" %in% recipes_to_run | sum(recipes_to_run == "all") == 1 | (is.null(recipes_to_run) & date_type %in% c("month", "quarter", "year")))){
 
           add_name <- paste0(model_name,"-R2",model_name_suffix)
           try(mdl_called <- invoke_forecast_function(fn_to_invoke =  model_fn,

--- a/R/forecast_models.R
+++ b/R/forecast_models.R
@@ -98,7 +98,7 @@ get_model_functions <- function(models_to_run,
   exhaustive_pre_load_list <- c(get_not_all_data_models(),
                                 get_r1_data_models(),
                                 get_r2_data_models())
-
+  
   deep_learning_models <- get_deep_learning_models()
   
   fnlist <- list()
@@ -189,7 +189,7 @@ invoke_forecast_function <- function(fn_to_invoke,
       inp_arg_list[x] <- avail_arg_list[x]
     }
   }
-
+  
   do.call(fn_to_invoke,inp_arg_list, quote=TRUE)
 }
 
@@ -249,8 +249,8 @@ construct_forecast_models <- function(full_data_tbl,
                                       date_regex,
                                       fiscal_year_start,
                                       seasonal_periods
-                                      ){
-
+){
+  
   forecast_models <- function(combo_value) {
     
     cli::cli_h2("Running Combo: {combo_value}")
@@ -267,14 +267,16 @@ construct_forecast_models <- function(full_data_tbl,
     
     #filter on specific combo or all data
     model_name_suffix <-  ifelse(combo_value=="All-Data","-all","")
-
+    
     run_data_full_tbl <- full_data_tbl %>%
       combo_specific_filter(combo_value,
                             combo_variables)
     
     cli::cli_h3("Initial Feature Engineering")
-
+    
     # recipe 1: standard feature engineering
+    run_data_full_recipe_1 <- NULL
+    
     if(is.null(recipes_to_run) | "R1" %in% recipes_to_run) {
       
       run_data_full_recipe_1 <- run_data_full_tbl %>%
@@ -292,9 +294,11 @@ construct_forecast_models <- function(full_data_tbl,
         dplyr::filter(Date > hist_end_date)
       
     }
-
+    
     # recipe 2: custom horizon specific feature engineering
-    if(is.null(recipes_to_run) | "R2" %in% recipes_to_run) {
+    run_data_full_recipe_2 <- NULL
+    
+    if((is.null(recipes_to_run) | "R2" %in% recipes_to_run) & date_type %in% c("month", "quarter", "year")) {
       
       run_data_full_recipe_2 <- run_data_full_tbl %>%
         multivariate_prep_recipe_2(external_regressors = external_regressors,
@@ -323,33 +327,33 @@ construct_forecast_models <- function(full_data_tbl,
     # create modeltime table to add single trained models to
     combined_models_recipe_1 <- modeltime::modeltime_table()
     combined_models_recipe_2 <- modeltime::modeltime_table()
-
+    
     # parallel processing
     if(run_model_parallel==TRUE & parallel_processing!="local_machine") {
       parallel_args <- init_parallel_within(parallel_processing, num_cores)
     }
-
+    
     cli::cli_h3("Individual Model Training")
-
+    
     model_list <- get_model_functions(models_to_run,
                                       models_not_to_run,
                                       run_deep_learning)
-
+    
     not_all_data_models <- get_not_all_data_models()
     r1_models <- get_r1_data_models()
     r2_models <- get_r2_data_models()
     freq_models <- get_frequency_adjustment_models()
     deep_nn_models <- get_deep_learning_models()
-
+    
     models_to_go_over <- names(model_list)
-
-
+    
+    
     for(model_name in models_to_go_over){
-
+      
       model_fn <- as.character(model_list[model_name])
-
+      
       cli::cli_alert_info("Function being called: {model_fn}")
-
+      
       if(model_name %in% not_all_data_models & combo_value != "All-Data"){
         if(model_name %in% freq_models){
           freq_val <- get_freq_adjustment(date_type,frequency_number)
@@ -357,59 +361,59 @@ construct_forecast_models <- function(full_data_tbl,
         else{
           freq_val <- frequency_number
         }
-
+        
         try(mdl_called <- invoke_forecast_function(fn_to_invoke =  model_fn,
-                                     train_data = train_data_recipe_1,
-                                     frequency = freq_val,
-                                     parallel = run_model_parallel,
-                                     horizon = forecast_horizon,
-                                     seasonal_period =seasonal_periods,
-                                     back_test_spacing = back_test_spacing,
-                                     fiscal_year_start = fiscal_year_start,
-                                     tscv_inital = hist_periods_80,
-                                     date_rm_regex = date_regex,
-                                     model_type = "single"))
+                                                   train_data = train_data_recipe_1,
+                                                   frequency = freq_val,
+                                                   parallel = run_model_parallel,
+                                                   horizon = forecast_horizon,
+                                                   seasonal_period =seasonal_periods,
+                                                   back_test_spacing = back_test_spacing,
+                                                   fiscal_year_start = fiscal_year_start,
+                                                   tscv_inital = hist_periods_80,
+                                                   date_rm_regex = date_regex,
+                                                   model_type = "single"))
         
         try(combined_models_recipe_1 <- modeltime::add_modeltime_model(combined_models_recipe_1,
                                                                        mdl_called,
                                                                        location = "top") %>%
               update_model_description(1, model_name),
             silent = TRUE)
-
+        
       }else{
-
-
+        
+        
         freq_val <- frequency
-
+        
         if((model_name %in% r1_models) | (model_name %in% r2_models)){
-
+          
           add_name <- paste0(model_name,"-R1",model_name_suffix)
           if(model_name %in% deep_nn_models){
             freq_val <- gluon_ts_frequency
             add_name <- paste0(model_name,model_name_suffix)
           }
-
-
-            try(mdl_called <- invoke_forecast_function(fn_to_invoke =  model_fn,
-                                                       train_data = train_data_recipe_1,
-                                                       frequency = freq_val,
-                                                       parallel = run_model_parallel,
-                                                       horizon = forecast_horizon,
-                                                       seasonal_period =seasonal_periods,
-                                                       back_test_spacing = back_test_spacing,
-                                                       fiscal_year_start = fiscal_year_start,
-                                                       tscv_inital = hist_periods_80,
-                                                       date_rm_regex = date_regex,
-                                                       model_type = "single"))
-
-            try(combined_models_recipe_1 <- modeltime::add_modeltime_model(combined_models_recipe_1,
-                                                                           mdl_called,
-                                                                           location = "top") %>%
-                  update_model_description(1, add_name),
-                silent = TRUE)
+          
+          
+          try(mdl_called <- invoke_forecast_function(fn_to_invoke =  model_fn,
+                                                     train_data = train_data_recipe_1,
+                                                     frequency = freq_val,
+                                                     parallel = run_model_parallel,
+                                                     horizon = forecast_horizon,
+                                                     seasonal_period =seasonal_periods,
+                                                     back_test_spacing = back_test_spacing,
+                                                     fiscal_year_start = fiscal_year_start,
+                                                     tscv_inital = hist_periods_80,
+                                                     date_rm_regex = date_regex,
+                                                     model_type = "single"))
+          
+          try(combined_models_recipe_1 <- modeltime::add_modeltime_model(combined_models_recipe_1,
+                                                                         mdl_called,
+                                                                         location = "top") %>%
+                update_model_description(1, add_name),
+              silent = TRUE)
         }
-
-        if(model_name %in% r2_models){
+        
+        if(model_name %in% r2_models & ("R2" %in% recipes_to_run | (is.null(recipes_to_run) & date_type %in% c("month", "quarter", "year")))){
 
           add_name <- paste0(model_name,"-R2",model_name_suffix)
           try(mdl_called <- invoke_forecast_function(fn_to_invoke =  model_fn,
@@ -423,17 +427,17 @@ construct_forecast_models <- function(full_data_tbl,
                                                      tscv_inital = hist_periods_80,
                                                      date_rm_regex = date_regex,
                                                      model_type = "single"))
-
+          
           try(combined_models_recipe_2 <- modeltime::add_modeltime_model(combined_models_recipe_2,
                                                                          mdl_called,
                                                                          location = "top") %>%
                 update_model_description(1, add_name),
               silent = TRUE)
         }
-
+        
       }
     }
-
+    
     print(combined_models_recipe_1)
     print(combined_models_recipe_2)
     
@@ -442,7 +446,7 @@ construct_forecast_models <- function(full_data_tbl,
     }
     
     cli::cli_h3("Refitting Individual Models")
-
+    
     #create resamples for back testing forecasts and ensemble training data
     
     # if multivariate models are chosen to run, ensemble models are turned on, and more than one individual model has been run, 
@@ -455,57 +459,61 @@ construct_forecast_models <- function(full_data_tbl,
       run_ensemble_models <- FALSE
     }
     
-    resamples_tscv_recipe_1 <- run_data_full_recipe_1 %>%
-      timetk::time_series_cv(
-        date_var = Date,
-        initial = "1 year",
-        assess = forecast_horizon,
-        skip = back_test_spacing,
-        cumulative = TRUE,
-        slice_limit = slice_limit_amount)
-
-    resamples_tscv_recipe_2 <- run_data_full_recipe_2 %>%
-      timetk::time_series_cv(
-        date_var = Date,
-        initial = "1 year",
-        assess = forecast_horizon,
-        skip = back_test_spacing,
-        cumulative = TRUE,
-        slice_limit = slice_limit_amount) %>%
-      timetk::tk_time_series_cv_plan()
-
-    #correctly filter test split to correct horizons per date
-    rsplit_function <- function(slice) {
-
-      train <- resamples_tscv_recipe_2 %>%
-        dplyr::filter(.id == slice,
-                      .key == "training")
-
-      test <- resamples_tscv_recipe_2 %>%
-        dplyr::filter(.id == slice,
-                      .key == "testing",
-                      Origin == max(train %>%
-                                      dplyr::filter(Horizon == 1) %>%
-                                      dplyr::select(Origin))+1)
-
-      slice_tbl <- train %>%
-        rbind(test) %>%
-        dplyr::select(-.id, -.key)
-
-      rsplit_obj <- slice_tbl %>%
-        rsample::make_splits(ind = list(analysis = seq(nrow(train)),
-                                        assessment = nrow(train) + seq(nrow(test))),
-                             class = "ts_cv_split")
-
-      return(rsplit_obj)
+    if(!is.null(run_data_full_recipe_1)) {
+      resamples_tscv_recipe_1 <- run_data_full_recipe_1 %>%
+        timetk::time_series_cv(
+          date_var = Date,
+          initial = "1 year",
+          assess = forecast_horizon,
+          skip = back_test_spacing,
+          cumulative = TRUE,
+          slice_limit = slice_limit_amount)
     }
 
-    split_objs <- purrr::map(unique(resamples_tscv_recipe_2$.id), .f=rsplit_function)
-
-    resamples_tscv_recipe_2_final <- rsample::new_rset(splits = split_objs,
-                                                       ids = unique(resamples_tscv_recipe_2$.id),
-                                                       subclass = c("time_series_cv", "rset"))
-
+    if(!is.null(run_data_full_recipe_2)) {
+      resamples_tscv_recipe_2 <- run_data_full_recipe_2 %>%
+        timetk::time_series_cv(
+          date_var = Date,
+          initial = "1 year",
+          assess = forecast_horizon,
+          skip = back_test_spacing,
+          cumulative = TRUE,
+          slice_limit = slice_limit_amount) %>%
+        timetk::tk_time_series_cv_plan()
+      
+      #correctly filter test split to correct horizons per date
+      rsplit_function <- function(slice) {
+        
+        train <- resamples_tscv_recipe_2 %>%
+          dplyr::filter(.id == slice,
+                        .key == "training")
+        
+        test <- resamples_tscv_recipe_2 %>%
+          dplyr::filter(.id == slice,
+                        .key == "testing",
+                        Origin == max(train %>%
+                                        dplyr::filter(Horizon == 1) %>%
+                                        dplyr::select(Origin))+1)
+        
+        slice_tbl <- train %>%
+          rbind(test) %>%
+          dplyr::select(-.id, -.key)
+        
+        rsplit_obj <- slice_tbl %>%
+          rsample::make_splits(ind = list(analysis = seq(nrow(train)),
+                                          assessment = nrow(train) + seq(nrow(test))),
+                               class = "ts_cv_split")
+        
+        return(rsplit_obj)
+      }
+      
+      split_objs <- purrr::map(unique(resamples_tscv_recipe_2$.id), .f=rsplit_function)
+      
+      resamples_tscv_recipe_2_final <- rsample::new_rset(splits = split_objs,
+                                                         ids = unique(resamples_tscv_recipe_2$.id),
+                                                         subclass = c("time_series_cv", "rset"))
+    }
+    
     get_model_time_resample_fit<- function(combined_models_recipe,
                                            resamples_tscv_recipe){
       combined_models_recipe %>%
@@ -526,11 +534,11 @@ construct_forecast_models <- function(full_data_tbl,
             dplyr::mutate(.row = dplyr::row_number()) %>%
             dplyr::ungroup())
     }
-
+    
     #refit models on resamples
     submodels_resample_tscv_recipe_1 <- tibble::tibble()
     submodels_resample_tscv_recipe_2 <- tibble::tibble()
-
+    
     if(length(unique(combined_models_recipe_1$.model_desc)) > 0) {
       submodels_resample_tscv_recipe_1 <- combined_models_recipe_1 %>%
         get_model_time_resample_fit(resamples_tscv_recipe_1)%>%
@@ -539,29 +547,29 @@ construct_forecast_models <- function(full_data_tbl,
         dplyr::mutate(Horizon = dplyr::row_number()) %>%
         dplyr::ungroup()
     }
-
+    
     if(length(unique(combined_models_recipe_2$.model_desc)) > 0) {
       submodels_resample_tscv_recipe_2 <- combined_models_recipe_2 %>%
         get_model_time_resample_fit(resamples_tscv_recipe_2_final) %>%
         dplyr::select(.id, Combo, Model, FCST, Target, Date, Horizon)
     }
-
+    
     submodels_resample_tscv_tbl <- rbind(submodels_resample_tscv_recipe_1,
                                          submodels_resample_tscv_recipe_2)
-
+    
     #Replace NaN/Inf with NA, then replace with zero
     is.na(submodels_resample_tscv_tbl) <- sapply(submodels_resample_tscv_tbl,
                                                  is.infinite)
     is.na(submodels_resample_tscv_tbl) <- sapply(submodels_resample_tscv_tbl,
                                                  is.nan)
     submodels_resample_tscv_tbl[is.na(submodels_resample_tscv_tbl)] = 0.01
-
+    
     ensemble_train_data_initial <- submodels_resample_tscv_tbl %>%
       dplyr::filter(Date <= hist_end_date) %>%
       dplyr::select(-.id) %>%
       tidyr::pivot_wider(names_from = "Model", values_from = "FCST") %>%
       dplyr::mutate(Horizon_char = as.character(Horizon))
-
+    
     #Replace NaN/Inf with NA, then replace with zero
     is.na(ensemble_train_data_initial) <- sapply(ensemble_train_data_initial,
                                                  is.infinite)
@@ -596,7 +604,7 @@ construct_forecast_models <- function(full_data_tbl,
     fcst_tbl <- tibble::tibble()
     
     if(run_ensemble_models) {
-    
+      
       cli::cli_h3("Ensemble Model Training")
       
       #create modeltime table to add ensembled trained models to
@@ -727,7 +735,7 @@ construct_forecast_models <- function(full_data_tbl,
     }
     
     cli::cli_h3("Forecast Output")
-
+    
     #Create forecast output
     fcst_tbl <- fcst_tbl %>%
       rbind(
@@ -736,11 +744,9 @@ construct_forecast_models <- function(full_data_tbl,
       rbind(
         submodels_resample_tscv_tbl %>%
           get_final_fcst_back_test())
-
+    
     return(fcst_tbl)
   }
-
+  
   return (forecast_models)
 }
-
-

--- a/R/forecast_time_series.R
+++ b/R/forecast_time_series.R
@@ -49,12 +49,12 @@
 #' @param fourier_periods List of values to use in creating fourier series as features. Default of NULL automatically chooses 
 #'   these values based on the date_type. 
 #' @param lag_periods List of values to use in creating lag features. Default of NULL automatically chooses these values 
-#'   based on date_type. 
+#'   based on date_type.
 #' @param rolling_window_periods List of values to use in creating rolling window features. Default of NULL automatically 
 #'   chooses these values based on date_type.
 #' @param recipes_to_run List of recipes to run on multivariate models that can run different recipes. A value of NULL runs 
-#'   all recipes, but only runs the R1 recipe for weekly and daily date types. A list like c("R1") or c("R2") would only 
-#'   run models with the R1 or R2 recipe.  
+#'   all recipes, but only runs the R1 recipe for weekly and daily date types. A value of "all" runs all recipes, regardless 
+#'   of date type. A list like c("R1") or c("R2") would only run models with the R1 or R2 recipe.  
 #' @param reticulate_environment File path to python environment to use when training gluonts deep learning models. 
 #'   Only important when parallel_processing is not set to 'azure_batch'. Azure Batch should use its own docker image 
 #'   that has python environment already installed. 

--- a/R/forecast_time_series.R
+++ b/R/forecast_time_series.R
@@ -24,7 +24,7 @@
 #'   values. 
 #' @param clean_outliers Should outliers be cleaned and inputted with values more in line with historical data?
 #' @param back_test_scenarios Number of specific back test folds to run when determining the best model. 
-#'   Default of 'auto' will automatially choose the number of back tests to run based on historical data size, 
+#'   Default of 'auto' will automatically choose the number of back tests to run based on historical data size, 
 #'   which tries to always use a minimum of 80% of the data when training a model. 
 #' @param back_test_spacing Number of periods to move back for each back test scenario. Default of 'auto' moves back 1
 #'   period at a time for year, quarter, and month data. Moves back 4 for week and 7 for day data. 
@@ -52,8 +52,9 @@
 #'   based on date_type. 
 #' @param rolling_window_periods List of values to use in creating rolling window features. Default of NULL automatically 
 #'   chooses these values based on date_type.
-#' @param recipes_to_run List of recipes to run on multivariate models. A value of NULL runs all recipes, but only runs the R1
-#'   recipe for weekly and daily date types. A list like c("R1") pr c("R2") would only run models with the R1 or R2 recipe.  
+#' @param recipes_to_run List of recipes to run on multivariate models that can run different recipes. A value of NULL runs 
+#'   all recipes, but only runs the R1 recipe for weekly and daily date types. A list like c("R1") or c("R2") would only 
+#'   run models with the R1 or R2 recipe.  
 #' @param reticulate_environment File path to python environment to use when training gluonts deep learning models. 
 #'   Only important when parallel_processing is not set to 'azure_batch'. Azure Batch should use its own docker image 
 #'   that has python environment already installed. 
@@ -63,7 +64,7 @@
 #' @param run_deep_learning Run deep learning models from gluonts (deepar and nbeats). Overrides models_to_run and 
 #'  models_not_to_run. 
 #' @param run_global_models Run multivariate models on the entire data set (across all time series) as a global model. 
-#'   Can be override by models_not_to_run. 
+#'   Can be override by models_not_to_run. Default of NULL runs global models for all date types except week and day. 
 #' @param run_local_models Run models by individual time series as local models.
 #' @param run_ensemble_models Run ensemble models 
 #' @param average_models Create simple averages of individual models. 
@@ -119,7 +120,7 @@ forecast_time_series <- function(input_data,
   models_to_run = NULL,
   models_not_to_run = NULL,
   run_deep_learning = FALSE, 
-  run_global_models = TRUE,
+  run_global_models = NULL,
   run_local_models = TRUE,
   run_ensemble_models = TRUE,
   average_models = TRUE,
@@ -280,11 +281,11 @@ forecast_time_series <- function(input_data,
                                                seasonal_periods)
   
   # * Run Forecast ----
-  if(forecast_approach == "bottoms_up" & length(unique(full_data_tbl$Combo)) > 1 & run_global_models & run_local_models) {
+  if(forecast_approach == "bottoms_up" & length(unique(full_data_tbl$Combo)) > 1 & (sum(run_global_models == TRUE) == 1 | (is.null(run_global_models) & date_type %in% c("month", "quarter", "year"))) & run_local_models) {
     
     combo_list <- c('All-Data', unique(full_data_tbl$Combo))
     
-  } else if(forecast_approach == "bottoms_up" & length(unique(full_data_tbl$Combo)) > 1 & run_global_models == TRUE & run_local_models == FALSE) {
+  } else if(forecast_approach == "bottoms_up" & length(unique(full_data_tbl$Combo)) > 1 & (sum(run_global_models == TRUE) == 1 | (is.null(run_global_models) & date_type %in% c("month", "quarter", "year"))) & run_local_models == FALSE) {
     
     combo_list <- c('All-Data')
     

--- a/R/forecast_time_series.R
+++ b/R/forecast_time_series.R
@@ -51,7 +51,9 @@
 #' @param lag_periods List of values to use in creating lag features. Default of NULL automatically chooses these values 
 #'   based on date_type. 
 #' @param rolling_window_periods List of values to use in creating rolling window features. Default of NULL automatically 
-#'   chooses these values based on date_type. 
+#'   chooses these values based on date_type.
+#' @param recipes_to_run List of recipes to run on multivariate models. A value of NULL runs all recipes, but only runs the R1
+#'   recipe for weekly and daily date types. A list like c("R1") pr c("R2") would only run models with the R1 or R2 recipe.  
 #' @param reticulate_environment File path to python environment to use when training gluonts deep learning models. 
 #'   Only important when parallel_processing is not set to 'azure_batch'. Azure Batch should use its own docker image 
 #'   that has python environment already installed. 
@@ -111,7 +113,8 @@ forecast_time_series <- function(input_data,
   negative_fcst = FALSE,
   fourier_periods = NULL, 
   lag_periods = NULL, 
-  rolling_window_periods = NULL, 
+  rolling_window_periods = NULL,
+  recipes_to_run = NULL,
   reticulate_environment = NULL,
   models_to_run = NULL,
   models_not_to_run = NULL,
@@ -120,11 +123,11 @@ forecast_time_series <- function(input_data,
   run_local_models = TRUE,
   run_ensemble_models = TRUE,
   average_models = TRUE,
-  max_model_average = 4,
+  max_model_average = 3,
   weekly_to_daily = TRUE
 ) {
 
-  # 1. Load Evironment Info: ----
+  # 1. Load Environment Info: ----
   
   load_env_info(reticulate_environment)
   
@@ -265,6 +268,7 @@ forecast_time_series <- function(input_data,
                                                num_cores,
                                                run_deep_learning,
                                                frequency_number,
+                                               recipes_to_run, 
                                                models_to_run,
                                                models_not_to_run,
                                                run_ensemble_models,

--- a/man/forecast_time_series.Rd
+++ b/man/forecast_time_series.Rd
@@ -33,15 +33,16 @@ forecast_time_series(
   fourier_periods = NULL,
   lag_periods = NULL,
   rolling_window_periods = NULL,
+  recipes_to_run = NULL,
   reticulate_environment = NULL,
   models_to_run = NULL,
   models_not_to_run = NULL,
   run_deep_learning = FALSE,
-  run_global_models = TRUE,
+  run_global_models = NULL,
   run_local_models = TRUE,
   run_ensemble_models = TRUE,
   average_models = TRUE,
-  max_model_average = 4,
+  max_model_average = 3,
   weekly_to_daily = TRUE
 )
 }
@@ -81,7 +82,7 @@ values.}
 \item{clean_outliers}{Should outliers be cleaned and inputted with values more in line with historical data?}
 
 \item{back_test_scenarios}{Number of specific back test folds to run when determining the best model.
-Default of 'auto' will automatially choose the number of back tests to run based on historical data size,
+Default of 'auto' will automatically choose the number of back tests to run based on historical data size,
 which tries to always use a minimum of 80\% of the data when training a model.}
 
 \item{back_test_spacing}{Number of periods to move back for each back test scenario. Default of 'auto' moves back 1
@@ -124,6 +125,10 @@ based on date_type.}
 \item{rolling_window_periods}{List of values to use in creating rolling window features. Default of NULL automatically
 chooses these values based on date_type.}
 
+\item{recipes_to_run}{List of recipes to run on multivariate models that can run different recipes. A value of NULL runs
+all recipes, but only runs the R1 recipe for weekly and daily date types. A value of "all" runs all recipes, regardless
+of date type. A list like c("R1") or c("R2") would only run models with the R1 or R2 recipe.}
+
 \item{reticulate_environment}{File path to python environment to use when training gluonts deep learning models.
 Only important when parallel_processing is not set to 'azure_batch'. Azure Batch should use its own docker image
 that has python environment already installed.}
@@ -137,7 +142,7 @@ any model.}
 models_not_to_run.}
 
 \item{run_global_models}{Run multivariate models on the entire data set (across all time series) as a global model.
-Can be override by models_not_to_run.}
+Can be override by models_not_to_run. Default of NULL runs global models for all date types except week and day.}
 
 \item{run_local_models}{Run models by individual time series as local models.}
 


### PR DESCRIPTION
- more control over recipes to run. With default of turning off R2 recipe for daily and weekly ML runs
- automatically turn off global models for daily and weekly ML runs
- change default max avg models from 4 to 3 to speed up run time

These fixes will help prevent ram issues when running daily/weekly ML forecasts in parallel