### PR TITLE
Users/mitokic/pca feature

### DIFF
--- a/R/configure_forecast_run.R
+++ b/R/configure_forecast_run.R
@@ -33,7 +33,7 @@ get_fourier_periods <- function(fourier_periods,
 #' 
 #' @param lag_periods lag_periods override
 #' @param date_type year, quarter, month, week, day
-#' @param forecast_horizon horion input from user
+#' @param forecast_horizon horizon input from user
 #' 
 #' @return Returns lag_periods
 #' @noRd
@@ -49,9 +49,7 @@ get_lag_periods <- function(lag_periods,
                     "quarter" = c(1,2,3,4),
                     "month" =  c(1, 2, 3, 6, 9, 12),
                     "week" = c(1, 2, 3, 4, 8, 12, 24, 48, 52),
-                    "day" = c(1, 2, 3, 4, 5, 6, 7, 14, 
-                              21, 28, 28*2, 28*3, 28*6, 
-                              28*9, 28*12, 365)
+                    "day" = c(7, 14, 21, 28, 60, 90, 180, 365)
                     )
   
   oplist <- c(oplist,forecast_horizon)

--- a/R/forecast_models.R
+++ b/R/forecast_models.R
@@ -164,7 +164,8 @@ invoke_forecast_function <- function(fn_to_invoke,
                                      date_rm_regex,
                                      back_test_spacing,
                                      fiscal_year_start,
-                                     model_type){
+                                     model_type,
+                                     pca){
   
   exp_arg_list <- formalArgs(fn_to_invoke)
   
@@ -177,7 +178,8 @@ invoke_forecast_function <- function(fn_to_invoke,
                          'date_rm_regex' = date_rm_regex,
                          'back_test_spacing' = back_test_spacing,
                          'fiscal_year_start' = fiscal_year_start,
-                         'model_type' = model_type)
+                         'model_type' = model_type, 
+                         "pca" = pca)
   
   avail_names <- names(avail_arg_list)
   
@@ -247,7 +249,8 @@ construct_forecast_models <- function(full_data_tbl,
                                       back_test_scenarios,
                                       date_regex,
                                       fiscal_year_start,
-                                      seasonal_periods
+                                      seasonal_periods, 
+                                      pca
                                       ){
 
   forecast_models <- function(combo_value) {
@@ -284,7 +287,6 @@ construct_forecast_models <- function(full_data_tbl,
     train_data_recipe_1 <- run_data_full_recipe_1 %>%
       dplyr::filter(Date <= hist_end_date)
 
-
     test_data_recipe_1 <- run_data_full_recipe_1 %>%
       dplyr::filter(Date > hist_end_date)
 
@@ -312,7 +314,9 @@ construct_forecast_models <- function(full_data_tbl,
       dplyr::filter(Date > hist_end_date,
                     Origin == train_origin_max+1)
 
-
+    # write.csv(train_data_recipe_2, "daily_data_R2.csv", row.names = FALSE)
+    # stop()
+    
     # create modeltime table to add single trained models to
     combined_models_recipe_1 <- modeltime::modeltime_table()
     combined_models_recipe_2 <- modeltime::modeltime_table()
@@ -361,7 +365,8 @@ construct_forecast_models <- function(full_data_tbl,
                                      fiscal_year_start = fiscal_year_start,
                                      tscv_inital = hist_periods_80,
                                      date_rm_regex = date_regex,
-                                     model_type = "single"))
+                                     model_type = "single", 
+                                     pca = pca))
         
         try(combined_models_recipe_1 <- modeltime::add_modeltime_model(combined_models_recipe_1,
                                                                        mdl_called,
@@ -393,7 +398,8 @@ construct_forecast_models <- function(full_data_tbl,
                                                        fiscal_year_start = fiscal_year_start,
                                                        tscv_inital = hist_periods_80,
                                                        date_rm_regex = date_regex,
-                                                       model_type = "single"))
+                                                       model_type = "single", 
+                                                       pca = pca))
 
             try(combined_models_recipe_1 <- modeltime::add_modeltime_model(combined_models_recipe_1,
                                                                            mdl_called,
@@ -415,7 +421,8 @@ construct_forecast_models <- function(full_data_tbl,
                                                      fiscal_year_start = fiscal_year_start,
                                                      tscv_inital = hist_periods_80,
                                                      date_rm_regex = date_regex,
-                                                     model_type = "single"))
+                                                     model_type = "single", 
+                                                     pca = pca))
 
           try(combined_models_recipe_2 <- modeltime::add_modeltime_model(combined_models_recipe_2,
                                                                          mdl_called,
@@ -615,7 +622,8 @@ construct_forecast_models <- function(full_data_tbl,
                                                      fiscal_year_start = fiscal_year_start,
                                                      tscv_inital = "1 year",
                                                      date_rm_regex = date_regex,
-                                                     model_type = "ensemble"))
+                                                     model_type = "ensemble", 
+                                                     pca = FALSE))
         
         try(combined_ensemble_models <- modeltime::add_modeltime_model(combined_ensemble_models,
                                                                        mdl_ensemble,

--- a/R/forecast_time_series.R
+++ b/R/forecast_time_series.R
@@ -52,7 +52,8 @@
 #'   based on date_type. 
 #' @param rolling_window_periods List of values to use in creating rolling window features. Default of NULL automatically 
 #'   chooses these values based on date_type. 
-#' @param pca Run principle component analysis on any lagged features to speed up model run time. 
+#' @param pca Run principle component analysis on any lagged features to speed up model run time. Default of NULL runs
+#'   PCA on day and week date types across all local multivariate models, and also for global models across all date types. 
 #' @param reticulate_environment File path to python environment to use when training gluonts deep learning models. 
 #'   Only important when parallel_processing is not set to 'azure_batch'. Azure Batch should use its own docker image 
 #'   that has python environment already installed. 
@@ -113,7 +114,7 @@ forecast_time_series <- function(input_data,
   fourier_periods = NULL, 
   lag_periods = NULL, 
   rolling_window_periods = NULL, 
-  pca = FALSE, 
+  pca = NULL, 
   reticulate_environment = NULL,
   models_to_run = NULL,
   models_not_to_run = NULL,

--- a/R/forecast_time_series.R
+++ b/R/forecast_time_series.R
@@ -52,6 +52,7 @@
 #'   based on date_type. 
 #' @param rolling_window_periods List of values to use in creating rolling window features. Default of NULL automatically 
 #'   chooses these values based on date_type. 
+#' @param pca Run principle component analysis on any lagged features to speed up model run time. 
 #' @param reticulate_environment File path to python environment to use when training gluonts deep learning models. 
 #'   Only important when parallel_processing is not set to 'azure_batch'. Azure Batch should use its own docker image 
 #'   that has python environment already installed. 
@@ -112,6 +113,7 @@ forecast_time_series <- function(input_data,
   fourier_periods = NULL, 
   lag_periods = NULL, 
   rolling_window_periods = NULL, 
+  pca = FALSE, 
   reticulate_environment = NULL,
   models_to_run = NULL,
   models_not_to_run = NULL,
@@ -273,7 +275,8 @@ forecast_time_series <- function(input_data,
                                                back_test_scenarios,
                                                date_regex,
                                                fiscal_year_start,
-                                               seasonal_periods)
+                                               seasonal_periods, 
+                                               pca)
   
   # * Run Forecast ----
   if(forecast_approach == "bottoms_up" & length(unique(full_data_tbl$Combo)) > 1 & run_global_models & run_local_models) {

--- a/R/multivariate_data_prep.R
+++ b/R/multivariate_data_prep.R
@@ -179,7 +179,7 @@ multivariate_prep_recipe_2 <- function(data, external_regressors, xregs_future_v
   
   #add horizon specific features
   if(date_type == 'day') {
-    lag_periods_r2 <- unique(c(1, 2, 3, 4, 5, 6, 7, 14, 21, 28, 28*2, 28*3, 28*6, 28*9, 28*12, 365, forecast_horizon))
+    lag_periods_r2 <- unique(c(7, 14, 21, 30, 90, 180, 365, forecast_horizon))
   } else {
     lag_periods_r2 <- 1:forecast_horizon
   }

--- a/man/arima_boost.Rd
+++ b/man/arima_boost.Rd
@@ -12,7 +12,8 @@ arima_boost(
   tscv_initial,
   date_rm_regex,
   back_test_spacing,
-  fiscal_year_start
+  fiscal_year_start,
+  pca
 )
 }
 \arguments{

--- a/man/cubist.Rd
+++ b/man/cubist.Rd
@@ -12,7 +12,8 @@ cubist(
   tscv_initial,
   date_rm_regex,
   back_test_spacing,
-  fiscal_year_start
+  fiscal_year_start,
+  pca
 )
 }
 \arguments{

--- a/man/forecast_time_series.Rd
+++ b/man/forecast_time_series.Rd
@@ -33,6 +33,7 @@ forecast_time_series(
   fourier_periods = NULL,
   lag_periods = NULL,
   rolling_window_periods = NULL,
+  pca = FALSE,
   reticulate_environment = NULL,
   models_to_run = NULL,
   models_not_to_run = NULL,
@@ -123,6 +124,8 @@ based on date_type.}
 
 \item{rolling_window_periods}{List of values to use in creating rolling window features. Default of NULL automatically
 chooses these values based on date_type.}
+
+\item{pca}{Run principle component analysis on any lagged features to speed up model run time.}
 
 \item{reticulate_environment}{File path to python environment to use when training gluonts deep learning models.
 Only important when parallel_processing is not set to 'azure_batch'. Azure Batch should use its own docker image

--- a/man/forecast_time_series.Rd
+++ b/man/forecast_time_series.Rd
@@ -33,7 +33,7 @@ forecast_time_series(
   fourier_periods = NULL,
   lag_periods = NULL,
   rolling_window_periods = NULL,
-  pca = FALSE,
+  pca = NULL,
   reticulate_environment = NULL,
   models_to_run = NULL,
   models_not_to_run = NULL,
@@ -125,7 +125,8 @@ based on date_type.}
 \item{rolling_window_periods}{List of values to use in creating rolling window features. Default of NULL automatically
 chooses these values based on date_type.}
 
-\item{pca}{Run principle component analysis on any lagged features to speed up model run time.}
+\item{pca}{Run principle component analysis on any lagged features to speed up model run time. Default of NULL runs
+PCA on day and week date types across all local multivariate models, and also for global models across all date types.}
 
 \item{reticulate_environment}{File path to python environment to use when training gluonts deep learning models.
 Only important when parallel_processing is not set to 'azure_batch'. Azure Batch should use its own docker image

--- a/man/glmnet.Rd
+++ b/man/glmnet.Rd
@@ -12,7 +12,8 @@ glmnet(
   tscv_initial,
   date_rm_regex,
   fiscal_year_start,
-  back_test_spacing
+  back_test_spacing,
+  pca
 )
 }
 \arguments{

--- a/man/mars.Rd
+++ b/man/mars.Rd
@@ -9,7 +9,8 @@ mars(
   parallel,
   model_type = "single",
   date_rm_regex,
-  fiscal_year_start
+  fiscal_year_start,
+  pca
 )
 }
 \arguments{

--- a/man/nnetar_xregs.Rd
+++ b/man/nnetar_xregs.Rd
@@ -12,7 +12,8 @@ nnetar_xregs(
   tscv_initial,
   date_rm_regex,
   fiscal_year_start,
-  back_test_spacing
+  back_test_spacing,
+  pca
 )
 }
 \arguments{

--- a/man/prophet_boost.Rd
+++ b/man/prophet_boost.Rd
@@ -11,7 +11,8 @@ prophet_boost(
   tscv_initial,
   date_rm_regex,
   fiscal_year_start,
-  back_test_spacing
+  back_test_spacing,
+  pca
 )
 }
 \arguments{

--- a/man/prophet_xregs.Rd
+++ b/man/prophet_xregs.Rd
@@ -11,7 +11,8 @@ prophet_xregs(
   tscv_initial,
   date_rm_regex,
   fiscal_year_start,
-  back_test_spacing
+  back_test_spacing,
+  pca
 )
 }
 \arguments{

--- a/man/svm_poly.Rd
+++ b/man/svm_poly.Rd
@@ -12,7 +12,8 @@ svm_poly(
   tscv_initial,
   date_rm_regex,
   fiscal_year_start,
-  back_test_spacing
+  back_test_spacing,
+  pca
 )
 }
 \arguments{

--- a/man/svm_rbf.Rd
+++ b/man/svm_rbf.Rd
@@ -12,7 +12,8 @@ svm_rbf(
   tscv_initial,
   date_rm_regex,
   fiscal_year_start,
-  back_test_spacing
+  back_test_spacing,
+  pca
 )
 }
 \arguments{

--- a/man/tabnet.Rd
+++ b/man/tabnet.Rd
@@ -4,7 +4,7 @@
 \alias{tabnet}
 \title{TabNet}
 \usage{
-tabnet(train_data, parallel, fiscal_year_start, date_rm_regex)
+tabnet(train_data, parallel, fiscal_year_start, date_rm_regex, pca)
 }
 \arguments{
 \item{train_data}{Training Data}

--- a/man/xgboost.Rd
+++ b/man/xgboost.Rd
@@ -12,7 +12,8 @@ xgboost(
   tscv_initial,
   date_rm_regex,
   fiscal_year_start,
-  back_test_spacing
+  back_test_spacing,
+  pca
 )
 }
 \arguments{


### PR DESCRIPTION
Added pca feature to run PCA as recipe step. 

By default, will run PCA for day/week date types, and will run PCA on global models regardless of date type. 

Main benefit is to speed up model run time with default inputs, and decreasing chances of memory/RAM issues when running forecasts in parallel (especially for day/week date types). 