### PR TITLE
Compatibility with dplyr 1.1.0

### DIFF
--- a/R/forecast_time_series.R
+++ b/R/forecast_time_series.R
@@ -234,7 +234,7 @@ forecast_time_series <- function(input_data,
   xregs_future_values_tbl <- data_tbl %>%
     dplyr::select(Combo, 
                   Date, 
-                  xregs_future_values_list) %>%
+                  dplyr::all_of(xregs_future_values_list)) %>%
     get_xregs_future_values_tbl(forecast_approach)
   
   external_regressors <- external_regressors %>%
@@ -729,7 +729,7 @@ forecast_time_series <- function(input_data,
                         lo.80 = Target, 
                         hi.80 = Target, 
                         hi.95 = Target) %>%
-          dplyr::select(Combo, combo_variables, Date, Model, Target, lo.95, lo.80, hi.80, hi.95) %>%
+          dplyr::select(Combo, dplyr::all_of(combo_variables), Date, Model, Target, lo.95, lo.80, hi.80, hi.95) %>%
           dplyr::filter(Date <= hist_end_date)
       ) %>%
       dplyr::arrange(Date, Combo, Model) %>%

--- a/R/multivariate_data_prep.R
+++ b/R/multivariate_data_prep.R
@@ -21,7 +21,7 @@ multivariate_prep_recipe_1 <- function(data, external_regressors, xregs_future_v
 
   for(column in c("Target", external_regressors)) {
 
-    if(is.numeric(dplyr::select(data, column)[[1]])) {
+    if(is.numeric(data[[column]])) {
       
       column_names_final <- c(column)
       
@@ -33,8 +33,7 @@ multivariate_prep_recipe_1 <- function(data, external_regressors, xregs_future_v
       if(column %in% external_regressors) {
         
         df_poly_column <- data %>%
-          dplyr::select(column) %>%
-          dplyr::rename(Col = column)
+          dplyr::select(Col = dplyr::all_of(column))
         
         temp_squared <- df_poly_column^2
         temp_cubed <- df_poly_column^3
@@ -59,10 +58,10 @@ multivariate_prep_recipe_1 <- function(data, external_regressors, xregs_future_v
       df_lag_final <- df
       
       #apply lags
-      for(column in colnames(df %>% dplyr::select(tidyselect::contains(c("Target", external_regressors))))) {
+      for(column in colnames(df %>% dplyr::select(tidyselect::contains(c("Target", dplyr::all_of(external_regressors)))))) {
 
         df_lag <- df %>%
-          timetk::tk_augment_lags(column, .lags = lag_periods) %>%
+          timetk::tk_augment_lags(dplyr::all_of(column), .lags = lag_periods) %>%
           tidyr::fill(stringr::str_c(column, "_lag", lag_periods), .direction = "up") %>%
           dplyr::select(stringr::str_c(column, "_lag", lag_periods))
         
@@ -80,9 +79,9 @@ multivariate_prep_recipe_1 <- function(data, external_regressors, xregs_future_v
         
         df_roll <- df_lag_final %>%
           dplyr::arrange(Date) %>%
-          tidyr::fill(column, .direction = "up") %>%
+          tidyr::fill(dplyr::all_of(column), .direction = "up") %>%
           timetk::tk_augment_slidify(
-            column, 
+            dplyr::all_of(column),
             .f = ~mean(.x, na.rm = TRUE),
             .period = rolling_window_periods,
             .partial = TRUE, 
@@ -90,7 +89,7 @@ multivariate_prep_recipe_1 <- function(data, external_regressors, xregs_future_v
             .names = stringr::str_c(column, "_roll", rolling_window_periods, "_Avg")
           ) %>%
           timetk::tk_augment_slidify(
-            column,
+            dplyr::all_of(column),
             .f = ~sum(.x, na.rm = TRUE),
             .period = rolling_window_periods,
             .partial = TRUE,
@@ -98,7 +97,7 @@ multivariate_prep_recipe_1 <- function(data, external_regressors, xregs_future_v
             .names = stringr::str_c(column, "_roll", rolling_window_periods, "_Sum")
           ) %>%
           timetk::tk_augment_slidify(
-            column,
+            dplyr::all_of(column),
             .f = ~sd(.x, na.rm = TRUE),
             .period = rolling_window_periods,
             .partial = TRUE,
@@ -120,7 +119,7 @@ multivariate_prep_recipe_1 <- function(data, external_regressors, xregs_future_v
   
   #drop xregs that do not contain future values
   data_period <- data_period %>%
-    dplyr::select(-numeric_xregs)
+    dplyr::select(-dplyr::all_of(numeric_xregs))
 
   return(data_period)
 }
@@ -151,7 +150,7 @@ multivariate_prep_recipe_2 <- function(data, external_regressors, xregs_future_v
   
   for(column in c("Target", external_regressors)) {
     
-    if(is.numeric(dplyr::select(data, column)[[1]])) {
+    if(is.numeric(data[[column]])) {
       
       column_names_final <- c(column)
       
@@ -163,8 +162,7 @@ multivariate_prep_recipe_2 <- function(data, external_regressors, xregs_future_v
       if(column %in% external_regressors) {
         
         df_poly_column <- data %>%
-          dplyr::select(column) %>%
-          dplyr::rename(Col = column)
+          dplyr::select(Col = dplyr::all_of(column))
         
         temp_squared <- df_poly_column^2
         temp_cubed <- df_poly_column^3
@@ -202,10 +200,10 @@ multivariate_prep_recipe_2 <- function(data, external_regressors, xregs_future_v
         #apply lags
         df_lag_final <- df
         
-        for(column in colnames(df %>% dplyr::select(tidyselect::contains(c("Target", external_regressors))))) {
+        for(column in colnames(df %>% dplyr::select(tidyselect::contains(c("Target", dplyr::all_of(external_regressors)))))) {
           
           df_lag <- df %>%
-            timetk::tk_augment_lags(column, .lags = unique(c(lag_periods_r2, lag_periods))+(period-1)) %>%
+            timetk::tk_augment_lags(dplyr::all_of(column), .lags = unique(c(lag_periods_r2, lag_periods))+(period-1)) %>%
             tidyr::fill(stringr::str_c(column, "_lag", unique(c(lag_periods_r2, lag_periods))+(period-1)), .direction = "up") %>%
             dplyr::select(stringr::str_c(column, "_lag", unique(c(lag_periods_r2, lag_periods))+(period-1))) 
           
@@ -223,9 +221,9 @@ multivariate_prep_recipe_2 <- function(data, external_regressors, xregs_future_v
           
           df_roll <- df_lag_final %>%
             dplyr::arrange(Date) %>%
-            tidyr::fill(column, .direction = "up") %>%
+            tidyr::fill(dplyr::all_of(column), .direction = "up") %>%
             timetk::tk_augment_slidify(
-              column,
+              dplyr::all_of(column),
               .f = ~mean(.x, na.rm = TRUE),
               .period = rolling_window_periods,
               .partial = TRUE,
@@ -233,7 +231,7 @@ multivariate_prep_recipe_2 <- function(data, external_regressors, xregs_future_v
               .names = stringr::str_c(column, "_roll", rolling_window_periods, "_Avg")
             ) %>%
             timetk::tk_augment_slidify(
-              column,
+              dplyr::all_of(column),
               .f = ~sum(.x, na.rm = TRUE),
               .period = rolling_window_periods,
               .partial = TRUE,
@@ -241,7 +239,7 @@ multivariate_prep_recipe_2 <- function(data, external_regressors, xregs_future_v
               .names = stringr::str_c(column, "_roll", rolling_window_periods, "_Sum")
             ) %>%
             timetk::tk_augment_slidify(
-              column,
+              dplyr::all_of(column),
               .f = ~sd(.x, na.rm = TRUE),
               .period = rolling_window_periods,
               .partial = TRUE,
@@ -267,7 +265,7 @@ multivariate_prep_recipe_2 <- function(data, external_regressors, xregs_future_v
     
     #drop xregs that do not contain future values
     data_period <- data_period %>%
-      dplyr::select(-numeric_xregs)
+      dplyr::select(-dplyr::all_of(numeric_xregs))
     
     #combine transformed data
     data_trans <- rbind(data_trans, data_period) 

--- a/R/prepare_hierarchy_data.R
+++ b/R/prepare_hierarchy_data.R
@@ -157,7 +157,7 @@ get_data_tbl_final <- function(data_tbl,
         
       data_cast <- df %>%
         dplyr::arrange(Combo, Date) %>%
-        dplyr::select(-combo_variables) %>%
+        dplyr::select(-dplyr::all_of(combo_variables)) %>%
         tidyr::pivot_wider(names_from = Combo, 
                            values_from = Target) %>%
         dplyr::mutate_if(is.numeric, list(~replace(., is.na(.), 0)))
@@ -223,7 +223,7 @@ get_poly_trans_clean <- function(df,
   df %>% 
     dplyr::mutate(
       dplyr::across(
-        (where(is.numeric) & c("Target", external_regressors)),
+        (where(is.numeric) & dplyr::all_of(c("Target", external_regressors))),
         correct_clean_func
         )
     ) %>%
@@ -312,7 +312,7 @@ get_full_data_tbl <- function(data_tbl,
     dplyr::select(Combo, 
                   Date, 
                   Target, 
-                  external_regressors) %>%
+                  dplyr::all_of(external_regressors)) %>%
     dplyr::group_by(Combo) %>%
     dplyr::group_split() %>%
     purrr::map(.f = function(df) { # latest update to timetk as of 11.18.21 doesn't allow for non NA pad value within dplyr groups. Filed bug and will update once fixed
@@ -331,7 +331,7 @@ get_full_data_tbl <- function(data_tbl,
                             .start_date = hist_start_date, 
                             .end_date = hist_end_date) %>% #fill in missing values at beginning of time series with zero
         dplyr::mutate(Combo = combo) %>%
-        dplyr::select(Combo, Date, Target, external_regressors)
+        dplyr::select(Combo, Date, Target, dplyr::all_of(external_regressors))
       
       return(pad_data)
     }) %>%

--- a/R/prepare_input_data.R
+++ b/R/prepare_input_data.R
@@ -15,10 +15,10 @@ get_data_tbl<- function(input_data,
   input_data %>%
     tibble::tibble() %>%
     tidyr::unite("Combo",
-          combo_variables,
+          dplyr::all_of(combo_variables),
           sep="--",
           remove=F) %>%
-    dplyr::rename("Target" =target_variable)
+    dplyr::rename("Target" = !!target_variable)
 }
 
 #' Gets the list of external regressors with future values
@@ -91,9 +91,9 @@ get_modelling_ready_tbl<-function(data_tbl,
   
   data_tbl %>%
     dplyr::select(c("Combo", 
-                    tidyselect::all_of(combo_variables), 
-                    tidyselect::all_of(external_regressors), 
-                    "Date", "Target")) %>%
+                    dplyr::all_of(c(combo_variables, external_regressors)),
+                    "Date",
+                    "Target")) %>%
     dplyr::filter(Date <= hist_end_date) %>%
     dplyr::arrange(Combo, Date) %>%
     combo_cleanup_func(combo_cleanup_date)

--- a/R/validate_forecasting_inputs.R
+++ b/R/validate_forecasting_inputs.R
@@ -67,7 +67,7 @@ validate_forecasting_inputs<-function(input_data,
   }
   
   #target variable is numeric
-  if(!input_data %>% dplyr::rename(Target = target_variable) %>% dplyr::pull(Target) %>% is.numeric()) {
+  if(!input_data %>% dplyr::rename(Target = !!target_variable) %>% dplyr::pull(Target) %>% is.numeric()) {
     stop("Target variable in input data needs to be numeric")
   }
   
@@ -169,10 +169,8 @@ validate_forecasting_inputs<-function(input_data,
     
     for(column in combo_variables) {
       
-      temp1 <- input_data %>%
-        dplyr::select(column)
-      
-      temp2 <- length(unique(temp1[[1]]))
+      temp1 <- input_data[[column]]
+      temp2 <- length(unique(temp1))
       
       
       combo_amount <- append(combo_amount, temp2)

--- a/tests/testthat/test-forecast_time_series.R
+++ b/tests/testthat/test-forecast_time_series.R
@@ -84,7 +84,7 @@ test_that("final forecast data rows are meaningful", {
   final_fc_dt <- final_fcst %>% 
     dplyr::filter(Type=="Historical") %>% 
     dplyr::filter(Date==max(Date)) %>%
-    dplyr::last()
+    dplyr::pull()
   
   print(paste("First Dt Val",final_fc_dt))
   
@@ -184,7 +184,7 @@ test_that("final forecast data rows are meaningful", {
   final_fc_dt <- final_fcst %>% 
     dplyr::filter(Type=="Historical") %>% 
     dplyr::filter(Date==max(Date)) %>%
-    dplyr::last()
+    dplyr::pull()
   
   print(paste("First Dt Val",final_fc_dt))
   
@@ -283,7 +283,7 @@ test_that("final forecast data rows are meaningful", {
   final_fc_dt <- final_fcst %>% 
     dplyr::filter(Type=="Historical") %>% 
     dplyr::filter(Date==max(Date)) %>%
-    dplyr::last()
+    dplyr::pull()
   
   print(paste("First Dt Val",final_fc_dt))
   


### PR DESCRIPTION
- Update tidyselect syntax to silence warnings (use `all_of()` with external vectors in particular)
- Use `pull()` instead of `last()`. As of dplyr 1.1.0, the latter returns the last row instead of the last column.

These changes are compatible with both CRAN and dev dplyr. If possible, a pre-emptive release would be helpful. We plan to release on January 27. Thanks!