### PR TITLE
bug fix for spark dataframes losing time series within prep_data for …

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: finnts
 Title: Microsoft Finance Time Series Forecasting Framework
-Version: 0.2.4.9003
+Version: 0.2.4.9004
 Authors@R: 
     c(person(given = "Mike",
            family = "Tokic",

--- a/R/train_models.R
+++ b/R/train_models.R
@@ -255,9 +255,8 @@ train_models <- function(run_info,
     .noexport = NULL
   ) %op%
     {
-      
       combo_hash <- x
-      
+
       model_recipe_tbl <- get_recipe_data(run_info,
         combo = x
       )


### PR DESCRIPTION
Fixes bug in prep_data where sparklyr can sometimes lose specific time series combos within spark_apply. Only seems to happen with large forecasts with thousands of time series. 