### PR TITLE
set.seed fix for hyperparameter creation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: finnts
 Title: Microsoft Finance Time Series Forecasting Framework
-Version: 0.2.4.9007
+Version: 0.2.4.9008
 Authors@R: 
     c(person(given = "Mike",
            family = "Tokic",

--- a/R/forecast_time_series.R
+++ b/R/forecast_time_series.R
@@ -183,7 +183,8 @@ forecast_time_series <- function(run_info = NULL,
     models_not_to_run,
     run_ensemble_models,
     pca,
-    num_hyperparameters = 10
+    num_hyperparameters = 10,
+    seed
   )
 
   train_models(run_info,

--- a/R/prep_models.R
+++ b/R/prep_models.R
@@ -69,6 +69,7 @@ prep_models <- function(run_info,
   check_input_type("models_not_to_run", models_not_to_run, c("NULL", "list", "character"))
   check_input_type("pca", pca, c("NULL", "logical"))
   check_input_type("num_hyperparameters", num_hyperparameters, "numeric")
+  check_input_type("seed", seed, "numeric")
 
   # create model workflows
   model_workflows(

--- a/R/prep_models.R
+++ b/R/prep_models.R
@@ -22,6 +22,7 @@
 #'   across all date types.
 #' @param num_hyperparameters number of hyperparameter combinations to test
 #'   out on validation data for model tuning.
+#' @param seed Set seed for random number generator. Numeric value.
 #'
 #' @return Writes outputs related to model prep to disk.
 #'
@@ -57,7 +58,8 @@ prep_models <- function(run_info,
                         models_not_to_run = NULL,
                         run_ensemble_models = TRUE,
                         pca = FALSE,
-                        num_hyperparameters = 10) {
+                        num_hyperparameters = 10,
+                        seed = 123) {
 
   # check input values
   check_input_type("run_info", run_info, "list")
@@ -79,7 +81,8 @@ prep_models <- function(run_info,
   # create model hyperparameters
   model_hyperparameters(
     run_info,
-    num_hyperparameters
+    num_hyperparameters,
+    seed
   )
 
   # create train test splits
@@ -627,11 +630,13 @@ model_workflows <- function(run_info,
 #'
 #' @param run_info run info
 #' @param num_hyperparameters number of hyperparameter combinations
+#' @param seed Set seed for random number generator. Numeric value.
 #'
 #' @return table of model hyperparameters
 #' @noRd
 model_hyperparameters <- function(run_info,
-                                  num_hyperparameters = 10) {
+                                  num_hyperparameters = 10,
+                                  seed = 123) {
   cli::cli_progress_step("Creating Model Hyperparameters")
 
   # check if input values have changed
@@ -749,6 +754,8 @@ model_hyperparameters <- function(run_info,
           workflows::extract_parameter_set_dials() %>%
           dials::finalize(recipe_features, force = FALSE)
       }
+
+      set.seed(seed)
 
       grid <- dials::grid_latin_hypercube(parameters, size = num_hyperparameters)
 

--- a/man/prep_models.Rd
+++ b/man/prep_models.Rd
@@ -12,7 +12,8 @@ prep_models(
   models_not_to_run = NULL,
   run_ensemble_models = TRUE,
   pca = FALSE,
-  num_hyperparameters = 10
+  num_hyperparameters = 10,
+  seed = 123
 )
 }
 \arguments{
@@ -41,6 +42,8 @@ across all date types.}
 
 \item{num_hyperparameters}{number of hyperparameter combinations to test
 out on validation data for model tuning.}
+
+\item{seed}{Set seed for random number generator. Numeric value.}
 }
 \value{
 Writes outputs related to model prep to disk.


### PR DESCRIPTION
Fixed bug to make each finn run reproducible, using the same hyperparameter values. 