### PR TITLE
add logic to prevent overly large forecast in hts recon process

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: finnts
 Title: Microsoft Finance Time Series Forecasting Framework
-Version: 0.3.0.9005
+Version: 0.3.0.9006
 Authors@R: 
     c(person(given = "Mike",
            family = "Tokic",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# finnts 0.3.0.9003 (DEVELOPMENT VERSION)
+# finnts 0.3.0.9000 (DEVELOPMENT VERSION)
 
 ## Improvements
 
@@ -12,6 +12,7 @@
 ## Bug Fixes
 
 -   Best model selection
+-   Hierarchical forecast reconciliation
 
 # finnts 0.3.0
 

--- a/R/hierarchy.R
+++ b/R/hierarchy.R
@@ -400,6 +400,9 @@ reconcile_hierarchical_data <- function(run_info,
 
             forecast_tbl <- model_tbl %>%
               dplyr::select(Date, Train_Test_ID, Combo, Forecast) %>%
+              dplyr::rowwise() %>%
+              dplyr::mutate(Forecast = ifelse(Forecast > 100000000000000, 100000000000000, Forecast)) %>%
+              dplyr::ungroup() %>%
               tidyr::pivot_wider(names_from = Combo, values_from = Forecast)
 
             forecast_tbl[is.na(forecast_tbl)] <- 0


### PR DESCRIPTION
limits future forecast to less than or equal to 100 trillion. Which fixes hts recon issue when forecasts are astronomically large. 