### PR TITLE
Mitokic/02182025/model fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: finnts
 Title: Microsoft Finance Time Series Forecasting Framework
-Version: 0.5.0.9001
+Version: 0.5.0.9002
 Authors@R: 
     c(person(given = "Mike",
            family = "Tokic",

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 -   Shortened global model list to just xgboost
 -   Faster xgboost model training for larger datasets 
 -   Faster feature selection for global model training
+-   Added `seasonal_period` within `prep_models()` for more control over multiple seasonal periods in models like tbats
 
 ## Bug Fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# finnts 0.5.9001 (development version)
+# finnts 0.5.0.9002 (development version)
 
 ## Improvements
 
@@ -9,6 +9,8 @@
 ## Bug Fixes
 
 -   Error in formatting of training data for global models
+-   Error when using multiple external regressors with future values
+-   Remove `target_log_transformation` within `prep_data()`, since `box_cox` has now replaced it for automated power transformations
 
 # finnts 0.5.0
 

--- a/R/forecast_time_series.R
+++ b/R/forecast_time_series.R
@@ -45,7 +45,6 @@
 #' @param num_cores Number of cores to run when parallel processing is set up. Used when running parallel computations
 #'   on local machine or within Azure. Default of NULL uses total amount of cores on machine minus one. Can't be greater
 #'   than number of cores on machine minus 1.
-#' @param target_log_transformation If TRUE, log transform target variable before training models.
 #' @param negative_forecast If TRUE, allow forecasts to dip below zero.
 #' @param fourier_periods List of values to use in creating fourier series as features. Default of NULL automatically chooses
 #'   these values based on the date_type.
@@ -126,7 +125,6 @@ forecast_time_series <- function(run_info = NULL,
                                  parallel_processing = NULL,
                                  inner_parallel = FALSE,
                                  num_cores = NULL,
-                                 target_log_transformation = FALSE,
                                  negative_forecast = FALSE,
                                  fourier_periods = NULL,
                                  lag_periods = NULL,
@@ -172,7 +170,6 @@ forecast_time_series <- function(run_info = NULL,
     forecast_approach = forecast_approach,
     parallel_processing = parallel_processing,
     num_cores = num_cores,
-    target_log_transformation = target_log_transformation,
     fourier_periods = fourier_periods,
     lag_periods = lag_periods,
     rolling_window_periods = rolling_window_periods,

--- a/R/models.R
+++ b/R/models.R
@@ -1053,8 +1053,8 @@ stlm_arima <- function(train_data,
 
   model_spec_stlm_arima <- modeltime::seasonal_reg(
     seasonal_period_1 = seasonal_period_stlm_arima[1],
-    seasonal_period_2 = seasonal_period_stlm_arima[2],
-    seasonal_period_3 = seasonal_period_stlm_arima[3]
+    seasonal_period_2 = if(is.na(seasonal_period_stlm_arima[2])) {NULL} else {seasonal_period_stlm_arima[2]},
+    seasonal_period_3 = if(is.na(seasonal_period_stlm_arima[3])) {NULL} else {seasonal_period_stlm_arima[3]}
   ) %>%
     parsnip::set_engine("stlm_arima")
 
@@ -1082,8 +1082,8 @@ stlm_ets <- function(train_data,
 
   model_spec_stlm_ets <- modeltime::seasonal_reg(
     seasonal_period_1 = seasonal_period_stlm_ets[1],
-    seasonal_period_2 = seasonal_period_stlm_ets[2],
-    seasonal_period_3 = seasonal_period_stlm_ets[3]
+    seasonal_period_2 = if(is.na(seasonal_period_stlm_ets[2])) {NULL} else {seasonal_period_stlm_ets[2]},
+    seasonal_period_3 = if(is.na(seasonal_period_stlm_ets[3])) {NULL} else {seasonal_period_stlm_ets[3]}
   ) %>%
     parsnip::set_engine("stlm_ets")
 
@@ -1273,8 +1273,8 @@ tbats <- function(train_data,
 
   model_spec_tbats <- modeltime::seasonal_reg(
     seasonal_period_1 = seasonal_period_tbats[1],
-    seasonal_period_2 = seasonal_period_tbats[2],
-    seasonal_period_3 = seasonal_period_tbats[3]
+    seasonal_period_2 = if(is.na(seasonal_period_tbats[2])) {NULL} else {seasonal_period_tbats[2]},
+    seasonal_period_3 = if(is.na(seasonal_period_tbats[3])) {NULL} else {seasonal_period_tbats[3]}
   ) %>%
     parsnip::set_engine("tbats")
 

--- a/R/multistep_helper.R
+++ b/R/multistep_helper.R
@@ -15,7 +15,7 @@ multi_future_xreg_check <- function(input_data,
     if (sum(external_regressors %in% colnames(input_data)) == 0) {
       future_xregs <- NULL
     } else {
-      future_xregs <- external_regressors[external_regressors %in% colnames(input_data)][[1]]
+      future_xregs <- unlist(intersect(external_regressors, colnames(input_data)), use.names = FALSE)
     }
   }
 

--- a/R/prep_data.R
+++ b/R/prep_data.R
@@ -34,7 +34,6 @@
 #' @param num_cores Number of cores to run when parallel processing is set up. Used when running parallel computations
 #'   on local machine or within Azure. Default of NULL uses total amount of cores on machine minus one. Can't be greater
 #'   than number of cores on machine minus 1.
-#' @param target_log_transformation If TRUE, log transform target variable before training models.
 #' @param fourier_periods List of values to use in creating fourier series as features. Default of NULL automatically chooses
 #'   these values based on the date_type.
 #' @param lag_periods List of values to use in creating lag features. Default of NULL automatically chooses these values
@@ -88,7 +87,6 @@ prep_data <- function(run_info,
                       forecast_approach = "bottoms_up",
                       parallel_processing = NULL,
                       num_cores = NULL,
-                      target_log_transformation = FALSE,
                       fourier_periods = NULL,
                       lag_periods = NULL,
                       rolling_window_periods = NULL,
@@ -115,7 +113,6 @@ prep_data <- function(run_info,
   check_input_type("forecast_approach", forecast_approach, "character", c("bottoms_up", "grouped_hierarchy", "standard_hierarchy"))
   check_input_type("parallel_processing", parallel_processing, c("character", "NULL"), c("NULL", "local_machine", "spark"))
   check_input_type("num_cores", num_cores, c("numeric", "NULL"))
-  check_input_type("target_log_transformation", target_log_transformation, "logical")
   check_input_type("fourier_periods", fourier_periods, c("list", "numeric", "NULL"))
   check_input_type("lag_periods", lag_periods, c("list", "numeric", "NULL"))
   check_input_type("rolling_window_periods", rolling_window_periods, c("list", "numeric", "NULL"))
@@ -243,7 +240,6 @@ prep_data <- function(run_info,
       forecast_approach = forecast_approach,
       parallel_processing = ifelse(is.null(parallel_processing), NA, parallel_processing),
       num_cores = ifelse(is.null(num_cores), NA, num_cores),
-      target_log_transformation = target_log_transformation,
       fourier_periods = ifelse(is.null(fourier_periods), NA, paste(fourier_periods, collapse = "---")),
       lag_periods = ifelse(is.null(lag_periods), NA, paste(lag_periods, collapse = "---")),
       rolling_window_periods = ifelse(is.null(rolling_window_periods), NA, paste(rolling_window_periods, collapse = "---")),
@@ -725,7 +721,6 @@ prep_data <- function(run_info,
       forecast_approach = forecast_approach,
       parallel_processing = ifelse(is.null(parallel_processing), NA, parallel_processing),
       num_cores = ifelse(is.null(num_cores), NA, num_cores),
-      target_log_transformation = target_log_transformation,
       fourier_periods = ifelse(is.null(fourier_periods), NA, paste(fourier_periods, collapse = "---")),
       lag_periods = ifelse(is.null(lag_periods), NA, paste(lag_periods, collapse = "---")),
       rolling_window_periods = ifelse(is.null(rolling_window_periods), NA, paste(rolling_window_periods, collapse = "---")),
@@ -752,26 +747,6 @@ prep_data <- function(run_info,
       folder = "prep_data",
       suffix = "-orig_combo_info"
     )
-  }
-}
-
-#' Function to perform log transformation
-#'
-#' @param df data frame
-#' @param target_log_transformation variable to indicate log transformation
-#'
-#' @return tbl with or without log transformation
-#' @noRd
-get_log_transformation <- function(df,
-                                   target_log_transformation) {
-  if (target_log_transformation) {
-    df %>%
-      dplyr::mutate(
-        Target = log1p(Target),
-        Target = ifelse(is.nan(Target), 0, Target)
-      )
-  } else {
-    df
   }
 }
 

--- a/R/prep_models.R
+++ b/R/prep_models.R
@@ -431,7 +431,7 @@ model_workflows <- function(run_info,
   forecast_approach <- log_df$forecast_approach
   forecast_horizon <- log_df$forecast_horizon
   multistep_horizon <- log_df$multistep_horizon
-  external_regressors <- ifelse(log_df$external_regressors == "NULL", NULL, strsplit(log_df$external_regressors, split = "---")[[1]])
+  external_regressors <- if(is.na(log_df$external_regressors)) {NULL} else {unlist(strsplit(log_df$external_regressors, split = "---"))}
 
   if (is.null(pca) & date_type %in% c("day", "week")) {
     pca <- TRUE

--- a/R/train_models.R
+++ b/R/train_models.R
@@ -93,7 +93,7 @@ train_models <- function(run_info,
   box_cox <- log_df$box_cox
   multistep_horizon <- log_df$multistep_horizon
   forecast_horizon <- log_df$forecast_horizon
-  external_regressors <- ifelse(log_df$external_regressors == "NULL", NULL, strsplit(log_df$external_regressors, split = "---")[[1]])
+  external_regressors <- if(is.na(log_df$external_regressors)) {NULL} else {unlist(strsplit(log_df$external_regressors, split = "---"))}
 
   if (is.null(run_global_models) & date_type %in% c("day", "week")) {
     run_global_models <- FALSE

--- a/man/forecast_time_series.Rd
+++ b/man/forecast_time_series.Rd
@@ -25,7 +25,6 @@ forecast_time_series(
   parallel_processing = NULL,
   inner_parallel = FALSE,
   num_cores = NULL,
-  target_log_transformation = FALSE,
   negative_forecast = FALSE,
   fourier_periods = NULL,
   lag_periods = NULL,
@@ -109,8 +108,6 @@ set to NULL or 'spark'.}
 \item{num_cores}{Number of cores to run when parallel processing is set up. Used when running parallel computations
 on local machine or within Azure. Default of NULL uses total amount of cores on machine minus one. Can't be greater
 than number of cores on machine minus 1.}
-
-\item{target_log_transformation}{If TRUE, log transform target variable before training models.}
 
 \item{negative_forecast}{If TRUE, allow forecasts to dip below zero.}
 

--- a/man/prep_data.Rd
+++ b/man/prep_data.Rd
@@ -23,7 +23,6 @@ prep_data(
   forecast_approach = "bottoms_up",
   parallel_processing = NULL,
   num_cores = NULL,
-  target_log_transformation = FALSE,
   fourier_periods = NULL,
   lag_periods = NULL,
   rolling_window_periods = NULL,
@@ -81,8 +80,6 @@ Value of 'spark' runs time series in parallel on a spark cluster in Azure Databr
 \item{num_cores}{Number of cores to run when parallel processing is set up. Used when running parallel computations
 on local machine or within Azure. Default of NULL uses total amount of cores on machine minus one. Can't be greater
 than number of cores on machine minus 1.}
-
-\item{target_log_transformation}{If TRUE, log transform target variable before training models.}
 
 \item{fourier_periods}{List of values to use in creating fourier series as features. Default of NULL automatically chooses
 these values based on the date_type.}

--- a/man/prep_models.Rd
+++ b/man/prep_models.Rd
@@ -13,11 +13,12 @@ prep_models(
   run_ensemble_models = TRUE,
   pca = NULL,
   num_hyperparameters = 10,
+  seasonal_period = NULL,
   seed = 123
 )
 }
 \arguments{
-\item{run_info}{run info using the \code{\link[=set_run_info]{set_run_info()}} function.}
+\item{run_info}{Run info using the \code{\link[=set_run_info]{set_run_info()}} function.}
 
 \item{back_test_scenarios}{Number of specific back test folds to run when
 determining the best model. Default of NULL will automatically choose
@@ -40,8 +41,10 @@ to speed up model run time. Default of NULL runs PCA on day and week
 date types across all local multivariate models, and also for global models
 across all date types.}
 
-\item{num_hyperparameters}{number of hyperparameter combinations to test
+\item{num_hyperparameters}{Number of hyperparameter combinations to test
 out on validation data for model tuning.}
+
+\item{seasonal_period}{List of numbers to be used for seasonal periods in specific univariate models like tbats.}
 
 \item{seed}{Set seed for random number generator. Numeric value.}
 }


### PR DESCRIPTION
This pull request includes several updates to the `finnts` package, focusing on improvements, bug fixes, and the removal of the `target_log_transformation` parameter. The most important changes include version updates, enhancements to model training speed, and added functionality for handling multiple seasonal periods.

Version updates:
* Updated package version from `0.5.0.9001` to `0.5.0.9002` in `DESCRIPTION` and `NEWS.md` files. [[1]](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL3-R3) [[2]](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaL1-R14)

Improvements:
* Shortened global model list to just xgboost and improved training speed for xgboost and feature selection.
* Added `seasonal_period` parameter within `prep_models()` for better control over multiple seasonal periods in models like tbats. [[1]](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaL1-R14) [[2]](diffhunk://#diff-d736363770f8fb8cda8c918ea9b19d79ae2419415b6dc29c8760e1b54ffab56cL22-R24) [[3]](diffhunk://#diff-d736363770f8fb8cda8c918ea9b19d79ae2419415b6dc29c8760e1b54ffab56cR62) [[4]](diffhunk://#diff-d736363770f8fb8cda8c918ea9b19d79ae2419415b6dc29c8760e1b54ffab56cR81)

Bug fixes:
* Fixed error in formatting training data for global models and issues with multiple external regressors with future values. [[1]](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaL1-R14) [[2]](diffhunk://#diff-464b0140989dabf26d01e314360f41d1fe61ceaa166bfdaee13fe95da06006a4L18-R18)
* Corrected handling of NA values for seasonal periods in various model functions (`stlm_arima`, `stlm_ets`, `tbats`). [[1]](diffhunk://#diff-f3f37c58b4cfc2367699d9b16ab0b014e3f9189f15008358dc0f04207f48cdc7L1056-R1057) [[2]](diffhunk://#diff-f3f37c58b4cfc2367699d9b16ab0b014e3f9189f15008358dc0f04207f48cdc7L1085-R1086) [[3]](diffhunk://#diff-f3f37c58b4cfc2367699d9b16ab0b014e3f9189f15008358dc0f04207f48cdc7L1276-R1277)

Removal of `target_log_transformation`:
* Removed the `target_log_transformation` parameter and related functionality from `forecast_time_series`, `prep_data`, and associated documentation. [[1]](diffhunk://#diff-64a9278f798d4d14b34ada3321daead1dbdc6f149832b6b16d2cacd3a655f3d9L48) [[2]](diffhunk://#diff-64a9278f798d4d14b34ada3321daead1dbdc6f149832b6b16d2cacd3a655f3d9L129) [[3]](diffhunk://#diff-64a9278f798d4d14b34ada3321daead1dbdc6f149832b6b16d2cacd3a655f3d9L175) [[4]](diffhunk://#diff-86992e862e8387cc32eb885654363fe4b6909978223d2f3a63f9fcfe2e732d4bL37) [[5]](diffhunk://#diff-86992e862e8387cc32eb885654363fe4b6909978223d2f3a63f9fcfe2e732d4bL91) [[6]](diffhunk://#diff-86992e862e8387cc32eb885654363fe4b6909978223d2f3a63f9fcfe2e732d4bL118) [[7]](diffhunk://#diff-86992e862e8387cc32eb885654363fe4b6909978223d2f3a63f9fcfe2e732d4bL246) [[8]](diffhunk://#diff-86992e862e8387cc32eb885654363fe4b6909978223d2f3a63f9fcfe2e732d4bL728) [[9]](diffhunk://#diff-86992e862e8387cc32eb885654363fe4b6909978223d2f3a63f9fcfe2e732d4bL758-L777) [[10]](diffhunk://#diff-b1c28908a8f6ff9eeb706d3b2085e3a6faeda36ab719ba11e3ed73b84d09a73eL28) [[11]](diffhunk://#diff-b1c28908a8f6ff9eeb706d3b2085e3a6faeda36ab719ba11e3ed73b84d09a73eL113-L114)