### PR TITLE
update github workflow for automated documentation

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -19,12 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
-        id: install-r
+      - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: 'release'
+          use-public-rspm: true
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building pkgdown documentation by upgrading the versions of key setup actions and enabling the use of the public RSPM. These changes help ensure compatibility with the latest features and improve reliability.

Workflow updates:

* Upgraded `r-lib/actions/setup-pandoc` from version 1 to version 2 in `.github/workflows/pkgdown.yaml`
* Upgraded `r-lib/actions/setup-r` from version 1 to version 2 and enabled `use-public-rspm` for improved package installation in `.github/workflows/pkgdown.yaml`