### PR TITLE
Mitokic/09102025/eda fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: finnts
 Title: Microsoft Finance Time Series Forecasting Framework
-Version: 0.6.0.9000
+Version: 0.6.0.9001
 Authors@R: 
     c(person(given = "Mike",
            family = "Tokic",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# finnts 0.6.0.9000 (development version)
+# finnts 0.6.0.9001 (development version)
 
 ## Improvements
 

--- a/R/agent_eda.R
+++ b/R/agent_eda.R
@@ -734,11 +734,11 @@ acf_scan <- function(agent_info,
 
       # calculate acf
       acf_result <- stats::acf(input_data$Target, plot = FALSE, lag.max = max_lag)
-      
+
       # calculate critical value for significance
       n_obs <- sum(!is.na(input_data$Target)) # length after any NA removal
       crit <- 1.96 / sqrt(n_obs) # two-sided 95 % limit
-      
+
       # convert to table and filter
       acf_tbl <- tibble::tibble(
         Combo = x,
@@ -877,14 +877,14 @@ pacf_scan <- function(agent_info,
 
       max_lag <- min(nrow(input_data) - 1, date_type_max_lag)
 
-      if(max_lag > 0) {
+      if (max_lag > 0) {
         # calculate pacf
         pacf_result <- stats::pacf(input_data$Target, plot = FALSE, lag.max = max_lag)
-        
+
         # calculate critical value for significance
         n_obs <- sum(!is.na(input_data$Target)) # length after any NA removal
         crit <- 1.96 / sqrt(n_obs) # two-sided 95 % limit
-        
+
         # convert to table and filter
         pacf_tbl <- tibble::tibble(
           Combo = x,
@@ -899,8 +899,8 @@ pacf_scan <- function(agent_info,
           dplyr::select(-Significant)
       } else {
         pacf_tbl <- tibble::tibble(
-          Combo = x, 
-          Lag = 1, 
+          Combo = x,
+          Lag = 1,
           Value = 0
         ) %>%
           dplyr::filter(Value > 0)


### PR DESCRIPTION
This pull request primarily refactors the exploratory data analysis (EDA) workflow in the `finnTs` package to improve clarity and maintainability. The main changes involve renaming the `get_finished_combos` function to `get_finished_eda_combos` and updating all related function calls. Additionally, there are small improvements to how parallel processing arguments are passed, and a minor bug fix in the PACF scan logic.

**Refactoring and Naming Consistency:**

* Renamed the function `get_finished_combos` to `get_finished_eda_combos` for clarity, and updated all references across EDA scan functions (`acf_scan`, `pacf_scan`, `stationarity_scan`, `missing_scan`, `outlier_scan`, `seasonality_scan`, `xreg_scan`) to use the new name. This improves code readability and makes the function's purpose clearer. [[1]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL665-R665) [[2]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL771-R771) [[3]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL810-R810) [[4]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL916-R925) [[5]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL956-R965) [[6]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL1046-R1055) [[7]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL1085-R1094) [[8]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL1172-R1181) [[9]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL1211-R1220) [[10]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL1350-R1359) [[11]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL1389-R1398) [[12]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL1527-R1536) [[13]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL1761-R1770) [[14]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL1876-R1885) [[15]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL1945-R1954)

**Argument Handling Improvements:**

* Updated the EDA workflow (`eda_agent_workflow`) to pass `parallel_processing` and `num_cores` as direct arguments instead of extracting them from `agent_info`. This makes the workflow more flexible and explicit. [[1]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL30-R31) [[2]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL41-R42) [[3]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL52-R53) [[4]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL63-R64) [[5]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL74-R75) [[6]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL85-R86) [[7]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL103-R104)

**Bug Fixes:**

* Fixed a bug in the PACF scan where, if the calculated `max_lag` was not greater than zero, the function would now return an empty result instead of failing or producing incorrect output. [[1]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cR880) [[2]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cR900-R907)

**Version and Documentation Updates:**

* Bumped the package version from `0.6.0.9000` to `0.6.0.9001` and updated the `NEWS.md` file to reflect the new development version. [[1]](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL3-R3) [[2]](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaL1-R1)