### PR TITLE
ensure all forecast runs in the agent have readable outputs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: finnts
 Title: Microsoft Finance Time Series Forecasting Framework
-Version: 0.6.0.9039
+Version: 0.6.0.9040
 Authors@R: 
     c(person(given = "Mike",
            family = "Tokic",
@@ -85,6 +85,7 @@ Suggests:
     sparklyr,
     testthat (>= 3.0.0), 
     tseries,
+    withr, 
     xgboost,
     vip
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# finnts 0.6.0.9039 (development version)
+# finnts 0.6.0.9040 (development version)
 
 ## Improvements
 

--- a/R/agent_iterate_forecast.R
+++ b/R/agent_iterate_forecast.R
@@ -1492,7 +1492,121 @@ submit_fcst_run <- function(agent_info,
     num_cores = num_cores
   )
 
+  # validate that all outputs can be loaded before proceeding
+  validate_run_outputs(
+    run_info = run_info,
+    combo = combo
+  )
+
   return(run_info)
+}
+
+#' Validate that all expected outputs from a forecast run can be loaded
+#'
+#' Checks that forecast data, trained model objects, and prep model objects
+#' (train_test_split, model_hyperparameters, model_workflows) are readable
+#' from disk. Stops with a descriptive error if any output cannot be loaded.
+#'
+#' @param run_info A list containing run information (project_name, run_name,
+#'   storage_object, path, data_output, object_output).
+#' @param combo A character string of the combo hash for local models, or NULL
+#'   for global models.
+#'
+#' @return TRUE invisibly if all outputs are valid.
+#' @noRd
+validate_run_outputs <- function(run_info, combo = NULL) {
+  # determine combo hash for file paths
+  if (is.null(combo)) {
+    forecast_combo <- "All-Data"
+    model_combo_hash <- hash_data("All-Data")
+  } else {
+    forecast_combo <- combo
+    model_combo_hash <- combo
+  }
+
+  # validate forecast data
+  fcst_tbl <- tryCatch(
+    load_combo_forecast(
+      combo = forecast_combo,
+      run_info = run_info
+    ),
+    error = function(e) NULL
+  ) %>%
+    base::suppressWarnings()
+
+  if (is.null(fcst_tbl) || nrow(fcst_tbl) == 0) {
+    stop(
+      "Failed to load forecast data for run '", run_info$run_name,
+      "' (combo: ", forecast_combo, "). ",
+      "Cannot log this as a best agent run.",
+      call. = FALSE
+    )
+  }
+
+  # validate trained models
+  trained_models_tbl <- tryCatch(
+    read_file(
+      run_info = run_info,
+      file_list = paste0(
+        run_info$path, "/models/",
+        hash_data(run_info$project_name), "-",
+        hash_data(run_info$run_name), "-",
+        model_combo_hash, "-single_models.",
+        run_info$object_output
+      ) %>% fs::path_tidy(),
+      return_type = "df"
+    ),
+    error = function(e) NULL
+  ) %>%
+    base::suppressWarnings()
+
+  if (is.null(trained_models_tbl) || nrow(trained_models_tbl) == 0) {
+    stop(
+      "Failed to load trained models for run '", run_info$run_name,
+      "' (combo: ", forecast_combo, "). ",
+      "Cannot log this as a best agent run.",
+      call. = FALSE
+    )
+  }
+
+  # validate prep model objects
+  data_path <- paste0(
+    run_info$path,
+    "/prep_models/", hash_data(run_info$project_name), "-",
+    hash_data(run_info$run_name)
+  )
+
+  prep_files <- list(
+    train_test_split = paste0(data_path, "-train_test_split.", run_info$data_output),
+    model_hyperparameters = paste0(data_path, "-model_hyperparameters.", run_info$object_output),
+    model_workflows = paste0(data_path, "-model_workflows.", run_info$object_output)
+  )
+
+  for (file_name in names(prep_files)) {
+    file_path <- fs::path_tidy(prep_files[[file_name]])
+
+    result <- tryCatch(
+      read_file(
+        run_info = run_info,
+        file_list = file_path,
+        return_type = "df"
+      ),
+      error = function(e) NULL
+    ) %>%
+      base::suppressWarnings()
+
+    if (is.null(result) || (is.data.frame(result) && nrow(result) == 0)) {
+      stop(
+        "Failed to load prep model object '", file_name,
+        "' for run '", run_info$run_name,
+        "' (combo: ", forecast_combo, "). ",
+        "Cannot log this as a best agent run.",
+        call. = FALSE
+      )
+    }
+  }
+
+  invisible(TRUE)
 }
 
 #' Get forecast output from a Finn run

--- a/R/agent_update_forecast.R
+++ b/R/agent_update_forecast.R
@@ -1802,6 +1802,12 @@ update_forecast_combo <- function(agent_info,
     suffix = NULL
   )
 
+  # validate that all outputs can be loaded before logging best run
+  validate_run_outputs(
+    run_info = new_run_info,
+    combo = if (combo == "All-Data") NULL else hash_data(combo)
+  )
+
   final_log_results <- log_best_run(
     agent_info = agent_info,
     run_info = new_run_info,

--- a/tests/testthat/test-agent.R
+++ b/tests/testthat/test-agent.R
@@ -812,9 +812,8 @@ test_that("validate_run_outputs errors when trained models are missing", {
   )
 
   # create forecast files so forecast validation passes
-  proj_hash <- digest::digest(project_name, algo = "xxhash64")
-  run_hash <- digest::digest(run_name, algo = "xxhash64")
-  tts_hash <- digest::digest(run_name, algo = "xxhash64")
+  proj_hash <- hash_data(project_name)
+  run_hash <- hash_data(run_name)
 
   fs::dir_create(fs::path(temp_dir, "forecasts"))
   fs::dir_create(fs::path(temp_dir, "prep_models"))

--- a/tests/testthat/test-agent.R
+++ b/tests/testthat/test-agent.R
@@ -771,6 +771,267 @@ test_that("update_forecast errors when forecast approach changes between runs", 
 
 # * Test update_forecast workflow ----
 
+# * Test validate_run_outputs ----
+
+test_that("validate_run_outputs errors when forecast data is missing", {
+  temp_dir <- tempfile("validate_test_")
+  on.exit(unlink(temp_dir, recursive = TRUE), add = TRUE)
+  fs::dir_create(temp_dir)
+
+  run_info <- list(
+    project_name = "test_project_local",
+    run_name = "test_run_1",
+    storage_object = NULL,
+    path = temp_dir,
+    data_output = "csv",
+    object_output = "rds"
+  )
+
+  expect_error(
+    validate_run_outputs(run_info = run_info, combo = "abc123"),
+    "Failed to load forecast data.*Cannot log this as a best agent run"
+  )
+})
+
+test_that("validate_run_outputs errors when trained models are missing", {
+  temp_dir <- tempfile("validate_test_")
+  on.exit(unlink(temp_dir, recursive = TRUE), add = TRUE)
+  fs::dir_create(temp_dir)
+
+  project_name <- "test_project_local"
+  run_name <- "test_run_2"
+  combo_hash <- "abc123"
+
+  run_info <- list(
+    project_name = project_name,
+    run_name = run_name,
+    storage_object = NULL,
+    path = temp_dir,
+    data_output = "csv",
+    object_output = "rds"
+  )
+
+  # create forecast files so forecast validation passes
+  proj_hash <- digest::digest(project_name, algo = "xxhash64")
+  run_hash <- digest::digest(run_name, algo = "xxhash64")
+  tts_hash <- digest::digest(run_name, algo = "xxhash64")
+
+  fs::dir_create(fs::path(temp_dir, "forecasts"))
+  fs::dir_create(fs::path(temp_dir, "prep_models"))
+
+  # write a minimal single_models forecast
+  fcst_df <- tibble::tibble(
+    Combo = "TestCombo",
+    Date = as.Date("2024-01-01"),
+    Model_ID = "arima--local--R1",
+    Model_Name = "arima",
+    Model_Type = "local",
+    Recipe_ID = "R1",
+    Train_Test_ID = 1,
+    Forecast = 100,
+    Target = 100,
+    Best_Model = "Yes",
+    Combo_ID = combo_hash,
+    Hyperparameter_ID = "hp1"
+  )
+  vroom::vroom_write(
+    fcst_df,
+    fs::path(temp_dir, "forecasts", paste0(proj_hash, "-", run_hash, "-", combo_hash, "-single_models.csv")),
+    delim = ","
+  )
+
+  # write a minimal train_test_split
+  tts_df <- tibble::tibble(Run_Type = "Back_Test", Train_Test_ID = 1)
+  vroom::vroom_write(
+    tts_df,
+    fs::path(temp_dir, "prep_models", paste0(proj_hash, "-", run_hash, "-train_test_split.csv")),
+    delim = ","
+  )
+
+  expect_error(
+    validate_run_outputs(run_info = run_info, combo = combo_hash),
+    "Failed to load trained models.*Cannot log this as a best agent run"
+  )
+})
+
+test_that("validate_run_outputs errors when prep model objects are missing", {
+  temp_dir <- tempfile("validate_test_")
+  on.exit(unlink(temp_dir, recursive = TRUE), add = TRUE)
+  fs::dir_create(temp_dir)
+
+  project_name <- "test_project_local"
+  run_name <- "test_run_3"
+  combo_hash <- "abc123"
+
+  run_info <- list(
+    project_name = project_name,
+    run_name = run_name,
+    storage_object = NULL,
+    path = temp_dir,
+    data_output = "csv",
+    object_output = "rds"
+  )
+
+  proj_hash <- digest::digest(project_name, algo = "xxhash64")
+  run_hash <- digest::digest(run_name, algo = "xxhash64")
+
+  fs::dir_create(fs::path(temp_dir, "forecasts"))
+  fs::dir_create(fs::path(temp_dir, "prep_models"))
+  fs::dir_create(fs::path(temp_dir, "models"))
+
+  # write a minimal single_models forecast
+  fcst_df <- tibble::tibble(
+    Combo = "TestCombo",
+    Date = as.Date("2024-01-01"),
+    Model_ID = "arima--local--R1",
+    Model_Name = "arima",
+    Model_Type = "local",
+    Recipe_ID = "R1",
+    Train_Test_ID = 1,
+    Forecast = 100,
+    Target = 100,
+    Best_Model = "Yes",
+    Combo_ID = combo_hash,
+    Hyperparameter_ID = "hp1"
+  )
+  vroom::vroom_write(
+    fcst_df,
+    fs::path(temp_dir, "forecasts", paste0(proj_hash, "-", run_hash, "-", combo_hash, "-single_models.csv")),
+    delim = ","
+  )
+
+  # write train_test_split
+  tts_df <- tibble::tibble(Run_Type = "Back_Test", Train_Test_ID = 1)
+  vroom::vroom_write(
+    tts_df,
+    fs::path(temp_dir, "prep_models", paste0(proj_hash, "-", run_hash, "-train_test_split.csv")),
+    delim = ","
+  )
+
+  # write trained models
+  models_df <- tibble::tibble(
+    Model_ID = "arima--local--R1",
+    Model_Name = "arima",
+    Model_Type = "local",
+    Recipe_ID = "R1",
+    Model_Fit = list(NULL)
+  )
+  saveRDS(
+    models_df,
+    fs::path(temp_dir, "models", paste0(proj_hash, "-", run_hash, "-", combo_hash, "-single_models.rds"))
+  )
+
+  # prep_models is missing model_hyperparameters and model_workflows
+  expect_error(
+    validate_run_outputs(run_info = run_info, combo = combo_hash),
+    "Failed to load prep model object.*Cannot log this as a best agent run"
+  )
+})
+
+test_that("validate_run_outputs succeeds when all outputs exist", {
+  temp_dir <- tempfile("validate_test_")
+  on.exit(unlink(temp_dir, recursive = TRUE), add = TRUE)
+  fs::dir_create(temp_dir)
+
+  project_name <- "test_project_local"
+  run_name <- "test_run_4"
+  combo_hash <- "abc123"
+
+  run_info <- list(
+    project_name = project_name,
+    run_name = run_name,
+    storage_object = NULL,
+    path = temp_dir,
+    data_output = "csv",
+    object_output = "rds"
+  )
+
+  proj_hash <- digest::digest(project_name, algo = "xxhash64")
+  run_hash <- digest::digest(run_name, algo = "xxhash64")
+
+  fs::dir_create(fs::path(temp_dir, "forecasts"))
+  fs::dir_create(fs::path(temp_dir, "prep_models"))
+  fs::dir_create(fs::path(temp_dir, "models"))
+
+  # write forecast
+  fcst_df <- tibble::tibble(
+    Combo = "TestCombo",
+    Date = as.Date("2024-01-01"),
+    Model_ID = "arima--local--R1",
+    Model_Name = "arima",
+    Model_Type = "local",
+    Recipe_ID = "R1",
+    Train_Test_ID = 1,
+    Forecast = 100,
+    Target = 100,
+    Best_Model = "Yes",
+    Combo_ID = combo_hash,
+    Hyperparameter_ID = "hp1"
+  )
+  vroom::vroom_write(
+    fcst_df,
+    fs::path(temp_dir, "forecasts", paste0(proj_hash, "-", run_hash, "-", combo_hash, "-single_models.csv")),
+    delim = ","
+  )
+
+  # write train_test_split
+  tts_df <- tibble::tibble(Run_Type = "Back_Test", Train_Test_ID = 1)
+  vroom::vroom_write(
+    tts_df,
+    fs::path(temp_dir, "prep_models", paste0(proj_hash, "-", run_hash, "-train_test_split.csv")),
+    delim = ","
+  )
+
+  # write trained models
+  models_df <- tibble::tibble(
+    Model_ID = "arima--local--R1",
+    Model_Name = "arima",
+    Model_Type = "local",
+    Recipe_ID = "R1",
+    Model_Fit = list(NULL)
+  )
+  saveRDS(
+    models_df,
+    fs::path(temp_dir, "models", paste0(proj_hash, "-", run_hash, "-", combo_hash, "-single_models.rds"))
+  )
+
+  # write model_hyperparameters and model_workflows
+  hp_df <- tibble::tibble(Model_Name = "arima", Hyperparameter = "default")
+  saveRDS(
+    hp_df,
+    fs::path(temp_dir, "prep_models", paste0(proj_hash, "-", run_hash, "-model_hyperparameters.rds"))
+  )
+
+  wf_df <- tibble::tibble(Model_Name = "arima", Workflow = list(NULL))
+  saveRDS(
+    wf_df,
+    fs::path(temp_dir, "prep_models", paste0(proj_hash, "-", run_hash, "-model_workflows.rds"))
+  )
+
+  expect_true(validate_run_outputs(run_info = run_info, combo = combo_hash))
+})
+
+test_that("validate_run_outputs works for global models (combo = NULL)", {
+  temp_dir <- tempfile("validate_test_")
+  on.exit(unlink(temp_dir, recursive = TRUE), add = TRUE)
+  fs::dir_create(temp_dir)
+
+  run_info <- list(
+    project_name = "test_project_global",
+    run_name = "test_run_5",
+    storage_object = NULL,
+    path = temp_dir,
+    data_output = "csv",
+    object_output = "rds"
+  )
+
+  # global models (combo = NULL) should error on missing forecast
+  expect_error(
+    validate_run_outputs(run_info = run_info, combo = NULL),
+    "Failed to load forecast data.*Cannot log this as a best agent run"
+  )
+})
+
 test_that("update_forecast completes with getter functions and ask_agent", {
   skip_if_not(has_llm_credentials(), "LLM credentials not available")
 


### PR DESCRIPTION
This pull request introduces a new validation step to ensure the integrity of forecast run outputs before logging a run as the "best agent run." The main addition is the `validate_run_outputs` function, which checks that all expected output files (forecast data, trained models, and prep model objects) exist and are readable. This validation is now integrated into both the forecast run submission and update workflows. Comprehensive unit tests have been added to verify this behavior under various scenarios.

**Forecast Output Validation:**

* Added a new internal function `validate_run_outputs` in `R/agent_iterate_forecast.R` to check that all required output files (forecast data, trained models, and prep model objects) for a forecast run are present and can be loaded. If any are missing or unreadable, a descriptive error is raised.
* Integrated `validate_run_outputs` into the forecast run submission (`submit_fcst_run`) and update (`update_forecast_combo`) workflows to prevent logging incomplete or invalid runs as best agent runs. [[1]](diffhunk://#diff-0c8a2fab8eac2442c77c71d71f1ecc55882b5a4ab0144f58fbd8d02ff42a3272R1495-R1611) [[2]](diffhunk://#diff-d13d143c911dbbf1f591277baf0060951aaa361914c6faba9952eede979aee1cR1805-R1810)

**Testing:**

* Added extensive unit tests in `tests/testthat/test-agent.R` to verify that `validate_run_outputs` correctly errors when forecast data, trained models, or prep model objects are missing, and succeeds when all outputs are present. Tests also cover both local and global model scenarios.

**Package Metadata:**

* Bumped the package version to `0.6.0.9040` and updated `NEWS.md` accordingly. [[1]](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL3-R3) [[2]](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaL1-R1)
* Added `withr` to the `Suggests` field in `DESCRIPTION` to support the new tests.