### PR TITLE
fix xreg issue with global models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: finnts
 Title: Microsoft Finance Time Series Forecasting Framework
-Version: 0.6.0.9040
+Version: 0.6.0.9041
 Authors@R: 
     c(person(given = "Mike",
            family = "Tokic",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# finnts 0.6.0.9040 (development version)
+# finnts 0.6.0.9041 (development version)
 
 ## Improvements
 
@@ -48,7 +48,8 @@
 -   Fixed weighted mape calculation when target variable has negative values.
 -   Support for latest xgboost 3x version.
 -   Fixed model summary for global models by considering average models too.
-  
+-   Fixed issue when future values of external regressors exist in some series but not all, leading to missing data issues when training a global model.
+
 ## Breaking Changes
 
 - `experiment_name` within `set_run_info()` has been changed to `project_name` to comply with new AI agent capabilities. 

--- a/R/input_checks.R
+++ b/R/input_checks.R
@@ -77,7 +77,8 @@ check_input_type <- function(input_name,
     stop(
       paste0(
         "invalid type for input name '", input_name, "', needs to be of type ",
-        glue::glue_collapse(type, " or ")
+        glue::glue_collapse(type, " or "),
+        " but got '", paste(class(input_value), collapse = "/"), "'"
       ),
       call. = FALSE
     )
@@ -117,17 +118,33 @@ check_input_data <- function(input_data,
                              parallel_processing) {
   # data combo names match the input data
   if (sum(combo_variables %in% colnames(input_data)) != length(combo_variables)) {
-    stop("combo variables do not match column headers in input data")
+    missing_vars <- setdiff(combo_variables, colnames(input_data))
+    stop(
+      "combo variables do not match column headers in input data. ",
+      "Missing columns: ", paste(missing_vars, collapse = ", "), ". ",
+      "Available columns: ", paste(colnames(input_data), collapse = ", "),
+      call. = FALSE
+    )
   }
 
   # target variable name matches the input data
   if (!(target_variable %in% colnames(input_data))) {
-    stop("target variable does not match a column header in input data")
+    stop(
+      "target variable '", target_variable, "' does not match a column header in input data. ",
+      "Available columns: ", paste(colnames(input_data), collapse = ", "),
+      call. = FALSE
+    )
   }
 
   # external regressors match the input data
   if (!is.null(external_regressors) & sum(external_regressors %in% colnames(input_data)) != length(external_regressors)) {
-    stop("external regressors do not match column headers in input data")
+    missing_xregs <- setdiff(external_regressors, colnames(input_data))
+    stop(
+      "external regressors do not match column headers in input data. ",
+      "Missing columns: ", paste(missing_xregs, collapse = ", "), ". ",
+      "Available columns: ", paste(colnames(input_data), collapse = ", "),
+      call. = FALSE
+    )
   }
 
   # 'Date' column is reserved for the time stamp
@@ -184,7 +201,14 @@ check_input_data <- function(input_data,
 
   # ensure month, quarter, year data repeats on the same day of each period
   if ((date_type != "day" & date_type != "week") & length(unique(format(input_data$Date, format = "%d"))) != 1) {
-    stop("historical date values are not evenly spaced")
+    unique_days <- unique(format(input_data$Date, format = "%d"))
+    stop(
+      "historical date values are not evenly spaced. ",
+      "For '", date_type, "' data, all dates must fall on the same day of the month ",
+      "(e.g., all on the 1st). Found dates on day(s): ",
+      paste(sort(unique_days), collapse = ", "),
+      call. = FALSE
+    )
   }
 
   # fiscal year start formatting
@@ -221,7 +245,14 @@ check_input_data <- function(input_data,
     dplyr::collect()
 
   if (nrow(duplicate_tbl) > 1) {
-    stop("duplicate rows have been detected in the input data",
+    dup_count <- nrow(duplicate_tbl)
+    dup_sample <- utils::head(duplicate_tbl, 5)
+    stop(
+      "duplicate rows have been detected in the input data. ",
+      "Found ", dup_count, " duplicate rows based on combo variables and Date. ",
+      "Sample duplicate dates: ",
+      paste(unique(dup_sample$Date), collapse = ", "), ". ",
+      "Remove duplicate rows so each combo-date combination is unique.",
       call. = FALSE
     )
   }

--- a/R/prep_data.R
+++ b/R/prep_data.R
@@ -315,11 +315,11 @@ prep_data <- function(run_info,
     global_future <- c()
     for (xr in external_regressors) {
       has_future <- initial_prep_tbl %>%
-        dplyr::filter(Date > hist_end_date) %>%
-        dplyr::select(tidyselect::all_of(xr)) %>%
-        tidyr::drop_na() %>%
-        nrow()
-      if (has_future > 0) {
+        dplyr::filter(Date > hist_end_date, !is.na(.data[[xr]])) %>%
+        dplyr::summarise(n = dplyr::n()) %>%
+        dplyr::collect() %>%
+        dplyr::pull(n)
+      if (isTRUE(has_future > 0)) {
         global_future <- c(global_future, xr)
       }
     }

--- a/R/prep_data.R
+++ b/R/prep_data.R
@@ -308,6 +308,26 @@ prep_data <- function(run_info,
   filtered_initial_prep_tbl <- initial_prep_tbl %>% # filter input data on combos that haven't completed running
     dplyr::filter(Combo %in% current_combo_list_final)
 
+  # compute global xregs_future_values_list across all combos so every combo
+  # keeps the same raw xreg columns in recipe output (prevents NA when combined)
+  global_xregs_future_list <- NULL
+  if (!is.null(external_regressors) && length(external_regressors) > 0) {
+    global_future <- c()
+    for (xr in external_regressors) {
+      has_future <- initial_prep_tbl %>%
+        dplyr::filter(Date > hist_end_date) %>%
+        dplyr::select(tidyselect::all_of(xr)) %>%
+        tidyr::drop_na() %>%
+        nrow()
+      if (has_future > 0) {
+        global_future <- c(global_future, xr)
+      }
+    }
+    if (length(global_future) > 0) {
+      global_xregs_future_list <- global_future
+    }
+  }
+
   # parallel run info
   if (is.null(parallel_processing) || parallel_processing == "local_machine") {
     par_info <- par_start(
@@ -349,20 +369,9 @@ prep_data <- function(run_info,
           dplyr::filter(Combo == combo) %>%
           dplyr::collect()
 
-        # external regressor handling
-        xregs_future_tbl <- get_xregs_future_values_tbl(
-          initial_prep_combo_tbl,
-          external_regressors,
-          hist_end_date
-        )
-
-        if (length(colnames(xregs_future_tbl)) > 2) {
-          xregs_future_list <- xregs_future_tbl %>%
-            dplyr::select(-Date, -Combo) %>%
-            colnames()
-        } else {
-          xregs_future_list <- NULL
-        }
+        # build join table for xregs that have future values globally
+        xregs_future_tbl <- initial_prep_combo_tbl %>%
+          dplyr::select(Combo, Date, tidyselect::any_of(global_xregs_future_list))
 
         # initial data prep
         initial_tbl <- initial_prep_combo_tbl %>%
@@ -371,7 +380,7 @@ prep_data <- function(run_info,
             Combo,
             Date,
             Target,
-            tidyselect::all_of(setdiff(external_regressors, xregs_future_list))
+            tidyselect::all_of(setdiff(external_regressors, global_xregs_future_list))
           ) %>%
           dplyr::group_by(Combo) %>%
           timetk::pad_by_time(Date,
@@ -413,7 +422,7 @@ prep_data <- function(run_info,
             dplyr::mutate(Target_Original = ifelse(Date > hist_end_date, NA, Target_Original))
         }
 
-        # preserve raw external regressors for TimeGPT
+        # preserve raw external regressors for foundation models that use raw xregs as features
         xreg_raw_df <- NULL
         if (!is.null(external_regressors) && length(external_regressors) > 0) {
           xreg_raw_df <- initial_tbl %>%
@@ -469,7 +478,7 @@ prep_data <- function(run_info,
         if (is.null(recipes_to_run) | "R1" %in% recipes_to_run | run_all_recipes_override) {
           R1 <- initial_tbl %>%
             multivariate_prep_recipe_1(external_regressors,
-              xregs_future_values_list = xregs_future_list,
+              xregs_future_values_list = global_xregs_future_list,
               get_fourier_periods(fourier_periods, date_type),
               get_lag_periods(lag_periods, date_type, forecast_horizon, multistep_horizon, TRUE),
               get_rolling_window_periods(rolling_window_periods, date_type),
@@ -492,7 +501,7 @@ prep_data <- function(run_info,
         if ((is.null(recipes_to_run) & date_type %in% c("month", "quarter", "year")) | "R2" %in% recipes_to_run | run_all_recipes_override) {
           R2 <- initial_tbl %>%
             multivariate_prep_recipe_2(external_regressors,
-              xregs_future_values_list = xregs_future_list,
+              xregs_future_values_list = global_xregs_future_list,
               get_fourier_periods(fourier_periods, date_type),
               get_lag_periods(lag_periods, date_type, forecast_horizon),
               get_rolling_window_periods(rolling_window_periods, date_type),
@@ -536,20 +545,9 @@ prep_data <- function(run_info,
             Combo_Hash = hash_data(combo)
           )
 
-          # handle external regressors
-          xregs_future_tbl <- get_xregs_future_values_tbl(
-            df,
-            external_regressors,
-            hist_end_date
-          )
-
-          if (length(colnames(xregs_future_tbl)) > 2) {
-            xregs_future_list <- xregs_future_tbl %>%
-              dplyr::select(-Date, -Combo) %>%
-              colnames()
-          } else {
-            xregs_future_list <- NULL
-          }
+          # build join table for xregs that have future values globally
+          xregs_future_tbl <- df %>%
+            dplyr::select(Combo, Date, tidyselect::any_of(global_xregs_future_list))
 
           # initial data prep
           initial_tbl <- df %>%
@@ -558,7 +556,7 @@ prep_data <- function(run_info,
               Combo,
               Date,
               Target,
-              tidyselect::all_of(external_regressors)
+              tidyselect::all_of(setdiff(external_regressors, global_xregs_future_list))
             ) %>%
             dplyr::group_by(Combo) %>%
             timetk::pad_by_time(Date,
@@ -656,7 +654,7 @@ prep_data <- function(run_info,
           if (is.null(recipes_to_run) | "R1" %in% recipes_to_run | run_all_recipes_override) {
             R1 <- initial_tbl %>%
               multivariate_prep_recipe_1(external_regressors,
-                xregs_future_values_list = xregs_future_list,
+                xregs_future_values_list = global_xregs_future_list,
                 get_fourier_periods(fourier_periods, date_type),
                 get_lag_periods(lag_periods, date_type, forecast_horizon, multistep_horizon, TRUE),
                 get_rolling_window_periods(rolling_window_periods, date_type),
@@ -679,7 +677,7 @@ prep_data <- function(run_info,
           if ((is.null(recipes_to_run) & date_type %in% c("month", "quarter", "year")) | "R2" %in% recipes_to_run | run_all_recipes_override) {
             R2 <- initial_tbl %>%
               multivariate_prep_recipe_2(external_regressors,
-                xregs_future_values_list = xregs_future_list,
+                xregs_future_values_list = global_xregs_future_list,
                 get_fourier_periods(fourier_periods, date_type),
                 get_lag_periods(lag_periods, date_type, forecast_horizon),
                 get_rolling_window_periods(rolling_window_periods, date_type),
@@ -702,7 +700,6 @@ prep_data <- function(run_info,
         },
         group_by = "Combo",
         context = list(
-          get_xregs_future_values_tbl = get_xregs_future_values_tbl,
           external_regressors = external_regressors,
           clean_missing_values = clean_missing_values,
           clean_outliers_missing_values = clean_outliers_missing_values,
@@ -732,7 +729,8 @@ prep_data <- function(run_info,
           box_cox = box_cox,
           stationary = stationary,
           make_stationary = make_stationary,
-          apply_box_cox = apply_box_cox
+          apply_box_cox = apply_box_cox,
+          global_xregs_future_list = global_xregs_future_list
         )
       )
   }
@@ -1279,6 +1277,7 @@ make_stationary <- function(df) {
 #' @param rolling_window_periods list of rolling window periods
 #' @param hist_end_date hist end date
 #' @param date_type date_type
+#' @param xreg_raw_df data frame of raw external regressor values for use in foundation models
 #'
 #' @return tbl with R1 feature engineering applied
 #' @noRd
@@ -1386,7 +1385,6 @@ multivariate_prep_recipe_1 <- function(data,
 
   is.na(data_lag_window) <- sapply(data_lag_window, is.nan)
   data_lag_window[is.na(data_lag_window)] <- 0.00
-
 
   if (!is.null(xreg_raw_df) && !is.null(external_regressors) && length(external_regressors) > 0) {
     for (xr in external_regressors) {

--- a/tests/testthat/test-prep_data.R
+++ b/tests/testthat/test-prep_data.R
@@ -15,8 +15,11 @@ test_that("prep_data grouped_hierarchy with mixed xreg future coverage has no NA
     dplyr::slice(rep(seq_len(dplyr::n()), each = length(all_dates))) %>%
     dplyr::mutate(
       Date = rep(all_dates, nrow(combos)),
-      Revenue = rep(runif(length(all_dates), 100, 500), nrow(combos)) +
-        rnorm(dplyr::n(), 0, 10)
+      Revenue = dplyr::if_else(
+        Date <= as.Date("2024-06-01"),
+        rep(runif(length(all_dates), 100, 500), nrow(combos)) + rnorm(dplyr::n(), 0, 10),
+        NA_real_
+      )
     )
 
   # Regressor_A: future values for ALL combos (fully covered)
@@ -50,6 +53,7 @@ test_that("prep_data grouped_hierarchy with mixed xreg future coverage has no NA
     date_type = "month",
     forecast_horizon = 3,
     external_regressors = c("Regressor_A", "Regressor_B"),
+    hist_end_date = as.Date("2024-06-01"),
     forecast_approach = "grouped_hierarchy",
     recipes_to_run = "R1",
     multistep_horizon = TRUE

--- a/tests/testthat/test-prep_data.R
+++ b/tests/testthat/test-prep_data.R
@@ -1,0 +1,120 @@
+test_that("prep_data grouped_hierarchy with mixed xreg future coverage has no NAs", {
+  # Synthetic 2×2 combo grid: Region × Segment
+  # 24 months history ending 2024-06-01, 3 future months
+  hist_dates <- seq.Date(as.Date("2022-07-01"), as.Date("2024-06-01"), by = "month")
+  future_dates <- seq.Date(as.Date("2024-07-01"), by = "month", length.out = 3)
+  all_dates <- c(hist_dates, future_dates)
+
+  combos <- tidyr::expand_grid(
+    Region = c("East", "West"),
+    Segment = c("Consumer", "Commercial")
+  )
+
+  set.seed(42)
+  data_tbl <- combos %>%
+    dplyr::slice(rep(seq_len(dplyr::n()), each = length(all_dates))) %>%
+    dplyr::mutate(
+      Date = rep(all_dates, nrow(combos)),
+      Revenue = rep(runif(length(all_dates), 100, 500), nrow(combos)) +
+        rnorm(dplyr::n(), 0, 10)
+    )
+
+  # Regressor_A: future values for ALL combos (fully covered)
+  data_tbl <- data_tbl %>%
+    dplyr::mutate(
+      Regressor_A = runif(dplyr::n(), 10, 50)
+    )
+
+  # Regressor_B: future values for ONLY East combos
+  # West combos get NA for future dates (simulates partial coverage)
+  data_tbl <- data_tbl %>%
+    dplyr::mutate(
+      Regressor_B = dplyr::case_when(
+        Date <= as.Date("2024-06-01") ~ runif(dplyr::n(), 5, 20),
+        Region == "East" ~ runif(dplyr::n(), 5, 20),
+        TRUE ~ NA_real_
+      )
+    )
+
+  run_info <- set_run_info()
+
+  # This is the scenario that previously caused NAs in recipe output:
+  # per-combo xregs_future_list would differ (East has both regressors with
+  # future values, West only has Regressor_A), causing inconsistent columns
+  # when recipes are combined for the global "All-Data" model.
+  prep_data(
+    run_info = run_info,
+    input_data = data_tbl,
+    combo_variables = c("Region", "Segment"),
+    target_variable = "Revenue",
+    date_type = "month",
+    forecast_horizon = 3,
+    external_regressors = c("Regressor_A", "Regressor_B"),
+    forecast_approach = "grouped_hierarchy",
+    recipes_to_run = "R1",
+    multistep_horizon = TRUE
+  )
+
+  prepped <- get_prepped_data(run_info, recipe = "R1")
+
+  # basic sanity
+
+  expect_gt(nrow(prepped), 0)
+
+  # all hierarchy combos should be present
+  combo_list <- unique(prepped$Combo)
+  expect_true("Total" %in% combo_list)
+  expect_true(any(grepl("^Region_", combo_list)))
+  expect_true(any(grepl("^Segment_", combo_list)))
+
+  # key check: no NAs in any numeric feature column
+  # Target is intentionally NA for future rows; _original columns may have
+  # intentional NAs for future periods (foundation model raw xregs)
+  feature_cols <- prepped %>%
+    dplyr::select(where(is.numeric)) %>%
+    dplyr::select(-tidyselect::any_of(c("Target", "Target_Original"))) %>%
+    dplyr::select(-tidyselect::matches("_original$")) %>%
+    colnames()
+
+  for (col in feature_cols) {
+    na_count <- sum(is.na(prepped[[col]]))
+    expect_equal(na_count, 0,
+      info = paste("Column", col, "has", na_count, "NAs")
+    )
+  }
+
+  # schema consistency: every combo should have the same numeric feature columns
+  # (combo variable columns like Region/Segment differ by hierarchy level)
+  combos_in_data <- unique(prepped$Combo)
+  col_sets <- lapply(combos_in_data, function(cb) {
+    prepped %>%
+      dplyr::filter(Combo == cb) %>%
+      dplyr::select(where(is.numeric)) %>%
+      colnames()
+  })
+  for (i in seq_along(col_sets)) {
+    expect_equal(sort(col_sets[[i]]), sort(col_sets[[1]]),
+      info = paste("Numeric column mismatch for combo:", combos_in_data[i])
+    )
+  }
+
+  # historical regressor-derived features should not be all zeros
+  hist_prepped <- prepped %>%
+    dplyr::filter(Date <= as.Date("2024-06-01"))
+
+  reg_a_cols <- grep("^Regressor_A", colnames(hist_prepped), value = TRUE)
+  reg_a_cols <- reg_a_cols[!grepl("(_lag|_roll|_original)", reg_a_cols)]
+  for (col in reg_a_cols) {
+    expect_false(all(hist_prepped[[col]] == 0),
+      info = paste("Historical", col, "should not be all zeros")
+    )
+  }
+
+  reg_b_cols <- grep("^Regressor_B", colnames(hist_prepped), value = TRUE)
+  reg_b_cols <- reg_b_cols[!grepl("(_lag|_roll|_original)", reg_b_cols)]
+  for (col in reg_b_cols) {
+    expect_false(all(hist_prepped[[col]] == 0),
+      info = paste("Historical", col, "should not be all zeros")
+    )
+  }
+})


### PR DESCRIPTION
This pull request addresses a critical issue in the `prep_data` workflow when handling external regressors (xregs) with future values that are present for some series but missing for others, particularly in global or grouped hierarchy models. The changes ensure that all combos maintain consistent feature columns and prevent missing data (NAs) in the output, even when future regressor coverage is partial. Additionally, the error messages for input validation have been improved to provide more detailed feedback, and a comprehensive test has been added to guard against regressions.

**Global handling of external regressors with partial future coverage:**

* Modified `prep_data` to compute a global list of external regressors (`global_xregs_future_list`) that have future values across all combos, ensuring consistent feature columns and preventing NAs in the recipe output for global/grouped hierarchy models. [[1]](diffhunk://#diff-86992e862e8387cc32eb885654363fe4b6909978223d2f3a63f9fcfe2e732d4bR311-R330) [[2]](diffhunk://#diff-86992e862e8387cc32eb885654363fe4b6909978223d2f3a63f9fcfe2e732d4bL352-R374) [[3]](diffhunk://#diff-86992e862e8387cc32eb885654363fe4b6909978223d2f3a63f9fcfe2e732d4bL374-R383) [[4]](diffhunk://#diff-86992e862e8387cc32eb885654363fe4b6909978223d2f3a63f9fcfe2e732d4bL416-R425) [[5]](diffhunk://#diff-86992e862e8387cc32eb885654363fe4b6909978223d2f3a63f9fcfe2e732d4bL472-R481) [[6]](diffhunk://#diff-86992e862e8387cc32eb885654363fe4b6909978223d2f3a63f9fcfe2e732d4bL495-R504) [[7]](diffhunk://#diff-86992e862e8387cc32eb885654363fe4b6909978223d2f3a63f9fcfe2e732d4bL539-R550) [[8]](diffhunk://#diff-86992e862e8387cc32eb885654363fe4b6909978223d2f3a63f9fcfe2e732d4bL561-R559) [[9]](diffhunk://#diff-86992e862e8387cc32eb885654363fe4b6909978223d2f3a63f9fcfe2e732d4bL659-R657) [[10]](diffhunk://#diff-86992e862e8387cc32eb885654363fe4b6909978223d2f3a63f9fcfe2e732d4bL682-R680) [[11]](diffhunk://#diff-86992e862e8387cc32eb885654363fe4b6909978223d2f3a63f9fcfe2e732d4bL705) [[12]](diffhunk://#diff-86992e862e8387cc32eb885654363fe4b6909978223d2f3a63f9fcfe2e732d4bL735-R733)

**Robustness and validation improvements:**

* Enhanced input validation error messages in `check_input_type` and `check_input_data` to include details about missing or mismatched columns and types, making debugging easier for users. [[1]](diffhunk://#diff-be7040606d84cf4ed42517e31b719feba88c854769ddbf0eb4ae5de2f004dbceL80-R81) [[2]](diffhunk://#diff-be7040606d84cf4ed42517e31b719feba88c854769ddbf0eb4ae5de2f004dbceL120-R147) [[3]](diffhunk://#diff-be7040606d84cf4ed42517e31b719feba88c854769ddbf0eb4ae5de2f004dbceL187-R211) [[4]](diffhunk://#diff-be7040606d84cf4ed42517e31b719feba88c854769ddbf0eb4ae5de2f004dbceL224-R255)

**Testing:**

* Added a comprehensive test to verify that `prep_data` produces no NAs and consistent feature columns when external regressors have mixed future coverage across combos, preventing regressions for this scenario.

**Documentation and metadata:**

* Updated version number and news to reflect the bugfix and new test coverage. [[1]](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL3-R3) [[2]](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaL1-R1) [[3]](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaR51)

**Minor technical documentation:**

* Improved function documentation for clarity regarding new parameters. [[1]](diffhunk://#diff-86992e862e8387cc32eb885654363fe4b6909978223d2f3a63f9fcfe2e732d4bR1280) [[2]](diffhunk://#diff-86992e862e8387cc32eb885654363fe4b6909978223d2f3a63f9fcfe2e732d4bL1390)