### PR TITLE
Som/Chronos Model Summary Bug Fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: finnts
 Title: Microsoft Finance Time Series Forecasting Framework
-Version: 0.6.0.9041
+Version: 0.6.0.9042
 Authors@R: 
     c(person(given = "Mike",
            family = "Tokic",

--- a/NEWS.md
+++ b/NEWS.md
@@ -49,7 +49,6 @@
 -   Support for latest xgboost 3x version.
 -   Fixed model summary for global models by considering average models too.
 -   Fixed issue when future values of external regressors exist in some series but not all, leading to missing data issues when training a global model.
--   Fixed model summary bugs for chronos models.
 
 ## Breaking Changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# finnts 0.6.0.9041 (development version)
+# finnts 0.6.0.9042 (development version)
 
 ## Improvements
 
@@ -49,6 +49,7 @@
 -   Support for latest xgboost 3x version.
 -   Fixed model summary for global models by considering average models too.
 -   Fixed issue when future values of external regressors exist in some series but not all, leading to missing data issues when training a global model.
+- Fixed model summary bugs for chronos models.
 
 ## Breaking Changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -49,7 +49,7 @@
 -   Support for latest xgboost 3x version.
 -   Fixed model summary for global models by considering average models too.
 -   Fixed issue when future values of external regressors exist in some series but not all, leading to missing data issues when training a global model.
-- Fixed model summary bugs for chronos models.
+-   Fixed model summary bugs for chronos models.
 
 ## Breaking Changes
 

--- a/R/agent_summarize_models.R
+++ b/R/agent_summarize_models.R
@@ -8073,24 +8073,15 @@ summarize_model_chronos2 <- function(wf) {
   preds_tbl <- .extract_predictors(mold)
   outs_tbl <- .extract_outcomes(mold)
 
-  # Flag external regressors (non-date predictors)
+  # Identify external regressors (non-date predictors)
   xreg_names <- character()
   if (!inherits(mold, "try-error") && !is.null(mold$predictors) && ncol(mold$predictors) > 0) {
     is_date <- vapply(mold$predictors, function(col) inherits(col, c("Date", "POSIXct", "POSIXt")), logical(1))
     xreg_names <- setdiff(names(mold$predictors)[!is_date], "Combo")
-    if (length(xreg_names) > 0 && nrow(preds_tbl) > 0) {
-      preds_tbl$value[preds_tbl$name %in% xreg_names] <-
-        paste0(preds_tbl$value[preds_tbl$name %in% xreg_names], " [regressor]")
-    }
   }
 
   # Recipe steps - no significant preprocessing steps for Chronos2
   steps_tbl <- tibble::tibble(section = character(), name = character(), value = character())
-
-  # Model arguments
-  arg_names <- c("forecast_horizon", "frequency")
-  arg_vals <- vapply(arg_names, function(nm) .format_numeric(.chr1(spec$args[[nm]])), FUN.VALUE = character(1))
-  args_tbl <- tibble::tibble(section = "model_arg", name = arg_names, value = arg_vals)
 
   # Engine params
   eng_tbl <- tibble::tibble(section = character(), name = character(), value = character())
@@ -8101,6 +8092,14 @@ summarize_model_chronos2 <- function(wf) {
   }
   chronos2_obj <- .find_obj(fit$fit, is_chronos2_fit, scan_depth)
   if (is.null(chronos2_obj) && is_chronos2_fit(fit$fit)) chronos2_obj <- fit$fit
+
+  # Model arguments - resolve from fit object to avoid unresolved quosures
+  arg_names <- c("forecast_horizon", "frequency")
+  arg_vals <- vapply(arg_names, function(nm) {
+    val <- if (!is.null(chronos2_obj) && !is.null(chronos2_obj[[nm]])) chronos2_obj[[nm]] else .chr1(spec$args[[nm]])
+    .format_numeric(as.character(val))
+  }, FUN.VALUE = character(1))
+  args_tbl <- tibble::tibble(section = "model_arg", name = arg_names, value = arg_vals)
 
   if (!is.null(chronos2_obj)) {
     # Training data stats - external regressors
@@ -8206,16 +8205,13 @@ summarize_model_chronos_bolt_base <- function(wf) {
 
   # Predictors / outcomes
   mold <- try(workflows::extract_mold(wf), silent = TRUE)
-  preds_tbl <- .extract_predictors(mold)
+  # Chronos Bolt Base does not use external regressors, keep only structural columns
+  preds_tbl <- .extract_predictors(mold) %>%
+    dplyr::filter(.data$name %in% c("Date", "Combo"))
   outs_tbl <- .extract_outcomes(mold)
 
   # No preprocessing steps for Chronos Bolt Base
   steps_tbl <- tibble::tibble(section = character(), name = character(), value = character())
-
-  # Model arguments
-  arg_names <- c("forecast_horizon", "frequency")
-  arg_vals <- vapply(arg_names, function(nm) .format_numeric(.chr1(spec$args[[nm]])), FUN.VALUE = character(1))
-  args_tbl <- tibble::tibble(section = "model_arg", name = arg_names, value = arg_vals)
 
   # Engine params
   eng_tbl <- tibble::tibble(section = character(), name = character(), value = character())
@@ -8225,6 +8221,14 @@ summarize_model_chronos_bolt_base <- function(wf) {
   }
   bolt_obj <- .find_obj(fit$fit, is_bolt_base_fit, 6)
   if (is.null(bolt_obj) && is_bolt_base_fit(fit$fit)) bolt_obj <- fit$fit
+
+  # Model arguments - resolve from fit object to avoid unresolved quosures
+  arg_names <- c("forecast_horizon", "frequency")
+  arg_vals <- vapply(arg_names, function(nm) {
+    val <- if (!is.null(bolt_obj) && !is.null(bolt_obj[[nm]])) bolt_obj[[nm]] else .chr1(spec$args[[nm]])
+    .format_numeric(as.character(val))
+  }, FUN.VALUE = character(1))
+  args_tbl <- tibble::tibble(section = "model_arg", name = arg_names, value = arg_vals)
 
   if (!is.null(bolt_obj)) {
     if (!is.null(bolt_obj$train_data)) {
@@ -8289,16 +8293,13 @@ summarize_model_chronos_bolt_tiny <- function(wf) {
 
   # Predictors / outcomes
   mold <- try(workflows::extract_mold(wf), silent = TRUE)
-  preds_tbl <- .extract_predictors(mold)
+  # Chronos Bolt Tiny does not use external regressors, keep only structural columns
+  preds_tbl <- .extract_predictors(mold) %>%
+    dplyr::filter(.data$name %in% c("Date", "Combo"))
   outs_tbl <- .extract_outcomes(mold)
 
   # No preprocessing steps for Chronos Bolt Tiny
   steps_tbl <- tibble::tibble(section = character(), name = character(), value = character())
-
-  # Model arguments
-  arg_names <- c("forecast_horizon", "frequency")
-  arg_vals <- vapply(arg_names, function(nm) .format_numeric(.chr1(spec$args[[nm]])), FUN.VALUE = character(1))
-  args_tbl <- tibble::tibble(section = "model_arg", name = arg_names, value = arg_vals)
 
   # Engine params
   eng_tbl <- tibble::tibble(section = character(), name = character(), value = character())
@@ -8308,6 +8309,14 @@ summarize_model_chronos_bolt_tiny <- function(wf) {
   }
   bolt_obj <- .find_obj(fit$fit, is_bolt_tiny_fit, 6)
   if (is.null(bolt_obj) && is_bolt_tiny_fit(fit$fit)) bolt_obj <- fit$fit
+
+  # Model arguments - resolve from fit object to avoid unresolved quosures
+  arg_names <- c("forecast_horizon", "frequency")
+  arg_vals <- vapply(arg_names, function(nm) {
+    val <- if (!is.null(bolt_obj) && !is.null(bolt_obj[[nm]])) bolt_obj[[nm]] else .chr1(spec$args[[nm]])
+    .format_numeric(as.character(val))
+  }, FUN.VALUE = character(1))
+  args_tbl <- tibble::tibble(section = "model_arg", name = arg_names, value = arg_vals)
 
   if (!is.null(bolt_obj)) {
     if (!is.null(bolt_obj$train_data)) {

--- a/R/agent_summarize_models.R
+++ b/R/agent_summarize_models.R
@@ -8073,13 +8073,6 @@ summarize_model_chronos2 <- function(wf) {
   preds_tbl <- .extract_predictors(mold)
   outs_tbl <- .extract_outcomes(mold)
 
-  # Identify external regressors (non-date predictors)
-  xreg_names <- character()
-  if (!inherits(mold, "try-error") && !is.null(mold$predictors) && ncol(mold$predictors) > 0) {
-    is_date <- vapply(mold$predictors, function(col) inherits(col, c("Date", "POSIXct", "POSIXt")), logical(1))
-    xreg_names <- setdiff(names(mold$predictors)[!is_date], "Combo")
-  }
-
   # Recipe steps - no significant preprocessing steps for Chronos2
   steps_tbl <- tibble::tibble(section = character(), name = character(), value = character())
 

--- a/tests/testthat/test-summarize_models.R
+++ b/tests/testthat/test-summarize_models.R
@@ -667,3 +667,151 @@ test_that("summarize timegpt with xregs", {
   )
   expect_gt(nrow(xreg_rows), 0)
 })
+
+# * Chronos model summarize ----
+
+chronos_train_data <- data.frame(
+  Date = seq.Date(as.Date("2020-01-01"), by = "month", length.out = 48),
+  Combo = "1",
+  Target = rnorm(48, mean = 100, sd = 10),
+  temperature_original = rnorm(48, mean = 20, sd = 5)
+)
+
+test_that("summarize chronos2 with xregs resolves args and reports regressors", {
+  recipe_spec <- get_recipe_foundation_model(chronos_train_data)
+  model_spec <- chronos2_model(forecast_horizon = 3, frequency = 12) %>%
+    parsnip::set_engine("chronos2_model")
+  wf <- workflows::workflow() %>%
+    workflows::add_recipe(recipe_spec) %>%
+    workflows::add_model(model_spec) %>%
+    generics::fit(chronos_train_data)
+
+  result <- summarize_model_chronos2(wf)
+  validate_summary_output(result, "chronos2")
+
+  fh_row <- result %>% dplyr::filter(section == "model_arg", name == "forecast_horizon")
+  expect_equal(nrow(fh_row), 1)
+  expect_equal(unname(fh_row$value), "3")
+
+  freq_row <- result %>% dplyr::filter(section == "model_arg", name == "frequency")
+  expect_equal(nrow(freq_row), 1)
+  expect_equal(unname(freq_row$value), "12")
+
+  mt_row <- result %>% dplyr::filter(section == "engine_param", name == "model_type")
+  expect_equal(nrow(mt_row), 1)
+  expect_equal(unname(mt_row$value), "chronos2")
+
+  nobs_row <- result %>% dplyr::filter(section == "engine_param", name == "n_training_obs")
+  expect_equal(nrow(nobs_row), 1)
+  expect_equal(unname(nobs_row$value), "48")
+
+  nxreg_row <- result %>% dplyr::filter(section == "engine_param", name == "n_external_regressors")
+  expect_equal(nrow(nxreg_row), 1)
+  expect_gt(as.integer(nxreg_row$value), 0)
+
+  # External regressors listed in engine params
+  xreg_list_row <- result %>% dplyr::filter(section == "engine_param", name == "external_regressors")
+  expect_equal(nrow(xreg_list_row), 1)
+  expect_true(grepl("temperature", xreg_list_row$value))
+
+  # Predictor row for the xreg column exists
+  xreg_pred <- result %>% dplyr::filter(section == "predictor", name == "temperature_original")
+  expect_equal(nrow(xreg_pred), 1)
+
+  # Importance rows present when external regressors exist
+  imp_rows <- result %>% dplyr::filter(section == "importance")
+  expect_gt(nrow(imp_rows), 0)
+})
+
+chronos_train_data_no_xregs <- data.frame(
+  Date = seq.Date(as.Date("2020-01-01"), by = "month", length.out = 48),
+  Combo = "1",
+  Target = rnorm(48, mean = 100, sd = 10)
+)
+
+test_that("summarize chronos2 without xregs reports zero regressors", {
+  recipe_spec <- get_recipe_simple(chronos_train_data_no_xregs)
+  model_spec <- chronos2_model(forecast_horizon = 3, frequency = 12) %>%
+    parsnip::set_engine("chronos2_model")
+  wf <- workflows::workflow() %>%
+    workflows::add_recipe(recipe_spec) %>%
+    workflows::add_model(model_spec) %>%
+    generics::fit(chronos_train_data_no_xregs %>% dplyr::select(-Combo))
+
+  result <- summarize_model_chronos2(wf)
+  validate_summary_output(result, "chronos2-no-xregs")
+
+  nxreg_row <- result %>% dplyr::filter(section == "engine_param", name == "n_external_regressors")
+  expect_equal(nrow(nxreg_row), 1)
+  expect_equal(unname(nxreg_row$value), "0")
+})
+
+test_that("summarize chronos-bolt-base resolves args and filters predictors to Date/Combo", {
+  recipe_spec <- get_recipe_foundation_model(chronos_train_data)
+  model_spec <- chronos_bolt_base_model(forecast_horizon = 6, frequency = 12) %>%
+    parsnip::set_engine("chronos_bolt_base_model")
+  wf <- workflows::workflow() %>%
+    workflows::add_recipe(recipe_spec) %>%
+    workflows::add_model(model_spec) %>%
+    generics::fit(chronos_train_data)
+
+  result <- summarize_model_chronos_bolt_base(wf)
+  validate_summary_output(result, "chronos-bolt-base")
+
+  fh_row <- result %>% dplyr::filter(section == "model_arg", name == "forecast_horizon")
+  expect_equal(nrow(fh_row), 1)
+  expect_equal(unname(fh_row$value), "6")
+
+  freq_row <- result %>% dplyr::filter(section == "model_arg", name == "frequency")
+  expect_equal(nrow(freq_row), 1)
+  expect_equal(unname(freq_row$value), "12")
+
+  preds <- result %>% dplyr::filter(section == "predictor")
+  expect_true(all(preds$name %in% c("Date", "Combo")))
+
+  mt_row <- result %>% dplyr::filter(section == "engine_param", name == "model_type")
+  expect_equal(nrow(mt_row), 1)
+  expect_equal(unname(mt_row$value), "chronos-bolt-base")
+
+  nobs_row <- result %>% dplyr::filter(section == "engine_param", name == "n_training_obs")
+  expect_equal(nrow(nobs_row), 1)
+
+  nxreg_row <- result %>% dplyr::filter(section == "engine_param", name == "n_external_regressors")
+  expect_equal(nrow(nxreg_row), 1)
+  expect_equal(unname(nxreg_row$value), "0")
+})
+
+test_that("summarize chronos-bolt-tiny resolves args and filters predictors to Date/Combo", {
+  recipe_spec <- get_recipe_foundation_model(chronos_train_data)
+  model_spec <- chronos_bolt_tiny_model(forecast_horizon = 4, frequency = 12) %>%
+    parsnip::set_engine("chronos_bolt_tiny_model")
+  wf <- workflows::workflow() %>%
+    workflows::add_recipe(recipe_spec) %>%
+    workflows::add_model(model_spec) %>%
+    generics::fit(chronos_train_data)
+
+  result <- summarize_model_chronos_bolt_tiny(wf)
+  validate_summary_output(result, "chronos-bolt-tiny")
+
+  fh_row <- result %>% dplyr::filter(section == "model_arg", name == "forecast_horizon")
+  expect_equal(nrow(fh_row), 1)
+  expect_equal(unname(fh_row$value), "4")
+
+  freq_row <- result %>% dplyr::filter(section == "model_arg", name == "frequency")
+  expect_equal(nrow(freq_row), 1)
+  expect_equal(unname(freq_row$value), "12")
+
+  preds <- result %>% dplyr::filter(section == "predictor")
+  expect_true(all(preds$name %in% c("Date", "Combo")))
+
+  mt_row <- result %>% dplyr::filter(section == "engine_param", name == "model_type")
+  expect_equal(nrow(mt_row), 1)
+  expect_equal(unname(mt_row$value), "chronos-bolt-tiny")
+
+  nobs_row <- result %>% dplyr::filter(section == "engine_param", name == "n_training_obs")
+  expect_equal(nrow(nobs_row), 1)
+
+  nxreg_row <- result %>% dplyr::filter(section == "engine_param", name == "n_external_regressors")
+  expect_equal(nrow(nxreg_row), 1)
+  expect_equal(unname(nxreg_row$value), "0")
+})


### PR DESCRIPTION

<img width="1878" height="726" alt="image" src="https://github.com/user-attachments/assets/7617949d-259d-43a9-bec3-0d8ece807b1c" />

This pull request focuses on fixing and improving the model summary logic for Chronos models in the `finnts` package, ensuring that model arguments are correctly extracted and external regressors are handled appropriately. The changes also update the package version and documentation to reflect these improvements and bug fixes.

Chronos model summary improvements and bug fixes:

* Updated the extraction of model arguments (`forecast_horizon`, `frequency`) in `summarize_model_chronos2`, `summarize_model_chronos_bolt_base`, and `summarize_model_chronos_bolt_tiny` to resolve values directly from the fit object, avoiding issues with unresolved quosures. [[1]](diffhunk://#diff-d76fde92a961aef9b0f996492a5e45f57057c70ec4351246bc0d2d970df2f91eR8096-R8103) [[2]](diffhunk://#diff-d76fde92a961aef9b0f996492a5e45f57057c70ec4351246bc0d2d970df2f91eR8225-R8232) [[3]](diffhunk://#diff-d76fde92a961aef9b0f996492a5e45f57057c70ec4351246bc0d2d970df2f91eR8313-R8320)
* For Chronos Bolt Base and Chronos Bolt Tiny models, restricted predictors to only structural columns (`Date`, `Combo`), explicitly excluding external regressors from summaries. [[1]](diffhunk://#diff-d76fde92a961aef9b0f996492a5e45f57057c70ec4351246bc0d2d970df2f91eL8209-L8219) [[2]](diffhunk://#diff-d76fde92a961aef9b0f996492a5e45f57057c70ec4351246bc0d2d970df2f91eL8292-L8302)
* Improved handling and labeling of external regressors in Chronos2 model summaries, clarifying their identification in the summary output.

Documentation and version updates:

* Incremented the package version to `0.6.0.9042` and updated the `NEWS.md` file to document the Chronos model summary bug fixes. [[1]](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL3-R3) [[2]](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaL1-R1) [[3]](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaR52)