### PR TITLE
fix issue with NA vals in xregs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: finnts
 Title: Microsoft Finance Time Series Forecasting Framework
-Version: 0.6.0.9042
+Version: 0.6.0.9043
 Authors@R: 
     c(person(given = "Mike",
            family = "Tokic",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# finnts 0.6.0.9042 (development version)
+# finnts 0.6.0.9043 (development version)
 
 ## Improvements
 
@@ -49,6 +49,7 @@
 -   Support for latest xgboost 3x version.
 -   Fixed model summary for global models by considering average models too.
 -   Fixed issue when future values of external regressors exist in some series but not all, leading to missing data issues when training a global model.
+-   Fixed issue around NA handling with external regressors. 
 
 ## Breaking Changes
 

--- a/R/prep_data.R
+++ b/R/prep_data.R
@@ -919,7 +919,7 @@ clean_outliers_missing_values <- function(df,
   }
 
   correct_clean_func <- function(col) {
-    if (clean_missing_values & sum(!is.na(col)) < 2) {
+    if (sum(!is.na(col)) < 2) {
       col
     } else if (clean_outliers) {
       timetk::ts_clean_vec(col, period = frequency_number)


### PR DESCRIPTION
This pull request is a patch release that addresses a bug in the handling of missing values with external regressors and makes a minor adjustment to the outlier and missing value cleaning logic. It also updates the package version and documentation accordingly.

Bug fixes and improvements:

* Fixed an issue with NA handling for external regressors, improving data preprocessing reliability.
* In the `clean_outliers_missing_values` function in `R/prep_data.R`, removed the dependency on the `clean_missing_values` flag when checking for columns with fewer than two non-NA values, ensuring columns are always returned unchanged in this case.

Documentation and versioning:

* Updated the package version to `0.6.0.9043` in `DESCRIPTION` and `NEWS.md`. [[1]](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL3-R3) [[2]](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaL1-R1)