### PR TITLE
fix hts recon when forecasts are very small and close to zero

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: finnts
 Title: Microsoft Finance Time Series Forecasting Framework
-Version: 0.6.0.9043
+Version: 0.6.0.9044
 Authors@R: 
     c(person(given = "Mike",
            family = "Tokic",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# finnts 0.6.0.9043 (development version)
+# finnts 0.6.0.9044 (development version)
 
 ## Improvements
 
@@ -50,6 +50,7 @@
 -   Fixed model summary for global models by considering average models too.
 -   Fixed issue when future values of external regressors exist in some series but not all, leading to missing data issues when training a global model.
 -   Fixed issue around NA handling with external regressors. 
+-   Fixed issue when reconciling hierarchical forecasts that are very close to zero.
 
 ## Breaking Changes
 

--- a/R/agent_iterate_forecast.R
+++ b/R/agent_iterate_forecast.R
@@ -349,9 +349,7 @@ iterate_forecast <- function(agent_info,
 
     reconcile_agent_forecast(
       agent_info = agent_info,
-      project_info = project_info,
-      parallel_processing = parallel_processing,
-      num_cores = num_cores
+      project_info = project_info
     )
 
     message("[agent] Saving Hierarchy Summary")

--- a/R/agent_update_forecast.R
+++ b/R/agent_update_forecast.R
@@ -310,9 +310,7 @@ update_fcst_agent_workflow <- function(agent_info,
       max_retry = 3,
       args = list(
         agent_info = agent_info,
-        project_info = project_info,
-        parallel_processing = parallel_processing,
-        num_cores = num_cores
+        project_info = project_info
       )
     ),
     save_hierarchy_summary = list(
@@ -1065,19 +1063,13 @@ analyze_results <- function(agent_info) {
 #'
 #' @param agent_info A list containing the agent information.
 #' @param project_info A list containing the project information.
-#' @param parallel_processing A character value indicating the type of parallel processing to use.
-#' @param num_cores Numeric indicating the number of cores to use for parallel processing.
 #'
 #' @return Nothing
 #' @noRd
 reconcile_agent_forecast <- function(agent_info,
-                                     project_info,
-                                     parallel_processing = NULL,
-                                     num_cores = NULL) {
+                                     project_info) {
   # formatting checks
   check_agent_info(agent_info = agent_info)
-  check_input_type("parallel_processing", parallel_processing, c("character", "NULL"), c("NULL", "local_machine", "spark"))
-  check_input_type("num_cores", num_cores, c("numeric", "NULL"))
 
   # load best run settings
   run_inputs <- get_best_agent_run(
@@ -2410,6 +2402,14 @@ reconcile <- function(initial_fcst,
 
   tryCatch(
     {
+      # floor small/negative forecasts to prevent slow nonnegative reconciliation
+      if (!negative_forecast) {
+        initial_fcst <- initial_fcst %>%
+          dplyr::mutate(
+            Forecast = ifelse(Forecast <= 0.001, 0.001, Forecast)
+          )
+      }
+
       run_type_tbl <- initial_fcst %>%
         dplyr::select(Train_Test_ID, Run_Type) %>%
         dplyr::distinct()

--- a/R/agent_update_forecast.R
+++ b/R/agent_update_forecast.R
@@ -2402,11 +2402,11 @@ reconcile <- function(initial_fcst,
 
   tryCatch(
     {
-      # floor small/negative forecasts to prevent slow nonnegative reconciliation
+      # floor near-zero forecasts to prevent slow nonnegative reconciliation
       if (!negative_forecast) {
         initial_fcst <- initial_fcst %>%
           dplyr::mutate(
-            Forecast = ifelse(Forecast <= 0.001, 0.001, Forecast)
+            Forecast = ifelse(Forecast > -0.0001 & Forecast < 0.0001, 0.0001, Forecast)
           )
       }
 

--- a/R/hierarchy.R
+++ b/R/hierarchy.R
@@ -636,6 +636,14 @@ reconcile_hierarchical_data <- function(run_info,
                 rbind(snaive_tbl)
             }
 
+            # floor small/negative forecasts to prevent slow nonnegative reconciliation
+            if (!negative_forecast) {
+              model_tbl <- model_tbl %>%
+                dplyr::mutate(
+                  Forecast = ifelse(Forecast <= 0.001, 0.001, Forecast)
+                )
+            }
+
             forecast_tbl <- model_tbl %>%
               dplyr::select(Date, Train_Test_ID, Combo, Forecast) %>%
               dplyr::mutate(Forecast = ifelse(Forecast > 100000000000000, 100000000000000, Forecast)) %>%
@@ -853,6 +861,14 @@ reconcile_hierarchical_data <- function(run_info,
 
               model_tbl <- model_tbl %>%
                 rbind(snaive_tbl)
+            }
+
+            # floor small/negative forecasts to prevent slow nonnegative reconciliation
+            if (!negative_forecast) {
+              model_tbl <- model_tbl %>%
+                dplyr::mutate(
+                  Forecast = ifelse(Forecast <= 0.001, 0.001, Forecast)
+                )
             }
 
             forecast_tbl <- model_tbl %>%

--- a/R/hierarchy.R
+++ b/R/hierarchy.R
@@ -636,11 +636,11 @@ reconcile_hierarchical_data <- function(run_info,
                 rbind(snaive_tbl)
             }
 
-            # floor small/negative forecasts to prevent slow nonnegative reconciliation
+            # floor near-zero forecasts to prevent slow nonnegative reconciliation
             if (!negative_forecast) {
               model_tbl <- model_tbl %>%
                 dplyr::mutate(
-                  Forecast = ifelse(Forecast <= 0.001, 0.001, Forecast)
+                  Forecast = ifelse(Forecast > -0.0001 & Forecast < 0.0001, 0.0001, Forecast)
                 )
             }
 
@@ -863,11 +863,11 @@ reconcile_hierarchical_data <- function(run_info,
                 rbind(snaive_tbl)
             }
 
-            # floor small/negative forecasts to prevent slow nonnegative reconciliation
+            # floor near-zero forecasts to prevent slow nonnegative reconciliation
             if (!negative_forecast) {
               model_tbl <- model_tbl %>%
                 dplyr::mutate(
-                  Forecast = ifelse(Forecast <= 0.001, 0.001, Forecast)
+                  Forecast = ifelse(Forecast > -0.0001 & Forecast < 0.0001, 0.0001, Forecast)
                 )
             }
 


### PR DESCRIPTION
This pull request addresses an issue with hierarchical forecast reconciliation when forecast values are very close to zero, which previously caused performance problems. The update floors near-zero forecast values to a small positive number to prevent slowdowns in nonnegative reconciliation. Additionally, the pull request removes unused parallel processing arguments from several internal functions for code simplification. The package version and NEWS are updated accordingly.

**Hierarchical Forecast Reconciliation Improvements:**

* Near-zero forecasts are now floored to 0.0001 before nonnegative reconciliation, preventing performance issues when reconciling hierarchical forecasts with values close to zero. This logic was added in both the `reconcile` function (`R/agent_update_forecast.R`) and twice in the `reconcile_hierarchical_data` function (`R/hierarchy.R`). [[1]](diffhunk://#diff-e7784ca5773ea0e525065f730a82b8ea57db2a6e082a99aa2ce5d45074977094R639-R646) [[2]](diffhunk://#diff-e7784ca5773ea0e525065f730a82b8ea57db2a6e082a99aa2ce5d45074977094R866-R873) [[3]](diffhunk://#diff-d13d143c911dbbf1f591277baf0060951aaa361914c6faba9952eede979aee1cR2405-R2412)
* The NEWS file documents the fix for issues when reconciling hierarchical forecasts that are very close to zero.

**Codebase Simplification:**

* Removed unused `parallel_processing` and `num_cores` arguments from the `reconcile_agent_forecast` function and its callers, simplifying function signatures and internal calls. [[1]](diffhunk://#diff-0c8a2fab8eac2442c77c71d71f1ecc55882b5a4ab0144f58fbd8d02ff42a3272L352-R352) [[2]](diffhunk://#diff-d13d143c911dbbf1f591277baf0060951aaa361914c6faba9952eede979aee1cL313-R313) [[3]](diffhunk://#diff-d13d143c911dbbf1f591277baf0060951aaa361914c6faba9952eede979aee1cL1068-L1080)

**Documentation and Versioning:**

* Updated the package version in `DESCRIPTION` and `NEWS.md` to 0.6.0.9044. [[1]](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL3-R3) [[2]](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaL1-R1)