### PR TITLE
update floor range for hts recon issues

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: finnts
 Title: Microsoft Finance Time Series Forecasting Framework
-Version: 0.6.0.9044
+Version: 0.6.0.9045
 Authors@R: 
     c(person(given = "Mike",
            family = "Tokic",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# finnts 0.6.0.9044 (development version)
+# finnts 0.6.0.9045 (development version)
 
 ## Improvements
 

--- a/R/agent_update_forecast.R
+++ b/R/agent_update_forecast.R
@@ -2406,7 +2406,7 @@ reconcile <- function(initial_fcst,
       if (!negative_forecast) {
         initial_fcst <- initial_fcst %>%
           dplyr::mutate(
-            Forecast = ifelse(Forecast > -0.0001 & Forecast < 0.0001, 0.0001, Forecast)
+            Forecast = ifelse(Forecast > -0.001 & Forecast < 0.001, 0.001, Forecast)
           )
       }
 

--- a/R/hierarchy.R
+++ b/R/hierarchy.R
@@ -640,7 +640,7 @@ reconcile_hierarchical_data <- function(run_info,
             if (!negative_forecast) {
               model_tbl <- model_tbl %>%
                 dplyr::mutate(
-                  Forecast = ifelse(Forecast > -0.0001 & Forecast < 0.0001, 0.0001, Forecast)
+                  Forecast = ifelse(Forecast > -0.001 & Forecast < 0.001, 0.001, Forecast)
                 )
             }
 
@@ -867,7 +867,7 @@ reconcile_hierarchical_data <- function(run_info,
             if (!negative_forecast) {
               model_tbl <- model_tbl %>%
                 dplyr::mutate(
-                  Forecast = ifelse(Forecast > -0.0001 & Forecast < 0.0001, 0.0001, Forecast)
+                  Forecast = ifelse(Forecast > -0.001 & Forecast < 0.001, 0.001, Forecast)
                 )
             }
 


### PR DESCRIPTION
This pull request updates the version of the `finnts` package and makes a small but important adjustment to how near-zero forecast values are handled in the forecasting logic. The main change is to increase the threshold for replacing near-zero forecasts with a minimum value, which can help with numerical stability and downstream processing.

Forecast value handling:

* Updated the threshold for setting minimum forecast values from ±0.0001 to ±0.001 in both the `reconcile` function (`R/agent_update_forecast.R`) and the `reconcile_hierarchical_data` function (`R/hierarchy.R`). Now, any forecast between -0.001 and 0.001 will be set to 0.001 if negative forecasts are not allowed. [[1]](diffhunk://#diff-d13d143c911dbbf1f591277baf0060951aaa361914c6faba9952eede979aee1cL2409-R2409) [[2]](diffhunk://#diff-e7784ca5773ea0e525065f730a82b8ea57db2a6e082a99aa2ce5d45074977094L643-R643) [[3]](diffhunk://#diff-e7784ca5773ea0e525065f730a82b8ea57db2a6e082a99aa2ce5d45074977094L870-R870)

Package metadata:

* Incremented the package version to 0.6.0.9045 in the `DESCRIPTION` and `NEWS.md` files. [[1]](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL3-R3) [[2]](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaL1-R1)