### PR TITLE
improve model avg speed when running multiple global models in spark

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: finnts
 Title: Microsoft Finance Time Series Forecasting Framework
-Version: 0.6.0.9045
+Version: 0.6.0.9046
 Authors@R: 
     c(person(given = "Mike",
            family = "Tokic",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# finnts 0.6.0.9045 (development version)
+# finnts 0.6.0.9046 (development version)
 
 ## Improvements
 

--- a/R/agent_iterate_forecast.R
+++ b/R/agent_iterate_forecast.R
@@ -1363,16 +1363,21 @@ submit_fcst_run <- function(agent_info,
   if (!is.null(parallel_processing)) {
     if (!is.null(combo) & parallel_processing == "spark") {
       # turn off parallel processing when running single combo
+      final_parallel <- NULL
       parallel_processing <- NULL
       prep_parallel <- NULL
     } else if (is.null(combo) & parallel_processing == "spark") {
       # local parallel process instead of spark on global models
+      # use spark when doing model averaging on multiple global models
+      final_parallel <- "spark"
       parallel_processing <- NULL
       prep_parallel <- "local_machine"
     } else {
+      final_parallel <- parallel_processing
       prep_parallel <- parallel_processing
     }
   } else {
+    final_parallel <- parallel_processing
     prep_parallel <- parallel_processing
   }
 
@@ -1479,13 +1484,24 @@ submit_fcst_run <- function(agent_info,
     debug = FALSE
   )
 
+  # use spark for model averaging only when multiple global models are run
+  if (identical(final_parallel, "spark") && global_models) {
+    global_model_count <- length(intersect(
+      null_converter(inputs$models_to_run),
+      list_global_models()
+    ))
+    if (global_model_count <= 1) {
+      final_parallel <- NULL
+    }
+  }
+
   # evaluate models
   final_models(
     run_info = run_info,
     average_models = TRUE,
     max_model_average = 3,
     weekly_to_daily = project_info$weekly_to_daily,
-    parallel_processing = parallel_processing,
+    parallel_processing = final_parallel,
     inner_parallel = inner_parallel,
     num_cores = num_cores
   )


### PR DESCRIPTION
This pull request updates the package version and introduces improvements to how parallel processing is handled in the forecasting workflow, especially regarding the use of Spark for model averaging with global models. The main focus is to ensure Spark is only used when it's beneficial (i.e., when multiple global models are involved), which optimizes resource usage and prevents unnecessary Spark sessions.

Key changes:

**Parallel processing logic improvements:**

* Refactored the logic in `submit_fcst_run` (in `R/agent_iterate_forecast.R`) to use the new `final_parallel` variable, ensuring Spark is only used for model averaging when multiple global models are being run. If only one global model is present, Spark is disabled for model averaging. [[1]](diffhunk://#diff-0c8a2fab8eac2442c77c71d71f1ecc55882b5a4ab0144f58fbd8d02ff42a3272R1366-R1380) [[2]](diffhunk://#diff-0c8a2fab8eac2442c77c71d71f1ecc55882b5a4ab0144f58fbd8d02ff42a3272R1487-R1504)

**Documentation and versioning:**

* Updated the package version in `DESCRIPTION` and `NEWS.md` to `0.6.0.9046` to reflect the new development changes. [[1]](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL3-R3) [[2]](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaL1-R1)