### PR TITLE
Mitokic/05122026/best model bug fix

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,5 @@ SUPPORT.md
 cran-comments.md
 ^CRAN-RELEASE$
 ^CRAN-SUBMISSION$
+^\.positai$
+^\.claude$

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ docs
 .github/copilot-instructions.md
 .github/prompts/
 .superpowers/
+.positai

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ docs
 .github/prompts/
 .superpowers/
 .positai
+.codex

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: finnts
 Title: Microsoft Finance Time Series Forecasting Framework
-Version: 0.6.0.9048
+Version: 0.6.0.9049
 Authors@R: 
     c(person(given = "Mike",
            family = "Tokic",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# finnts 0.6.0.9048 (development version)
+# finnts 0.6.0.9049 (development version)
 
 ## Improvements
 
@@ -60,6 +60,7 @@
 -   Fixed issue when future values of external regressors exist in some series but not all, leading to missing data issues when training a global model.
 -   Fixed issue around NA handling with external regressors. 
 -   Fixed issue when reconciling hierarchical forecasts that are very close to zero.
+-   Fixed issue when checking if best models have been selected before. 
 
 ## Breaking Changes
 

--- a/R/final_models.R
+++ b/R/final_models.R
@@ -108,7 +108,8 @@ final_models <- function(run_info,
   }
 
   # define columns to check for input changes
-  cols_check_list <- c("average_models", "max_model_average")
+  cols_check_list <- c("average_models", "max_model_average", 
+                       "weekly_to_daily", "weighted_mape")
 
   # check if input values have changed from previous run
   if (all(cols_check_list %in% colnames(prev_log_df))) {


### PR DESCRIPTION
This pull request updates the package version and includes a bug fix related to model selection checks, as well as minor maintenance improvements. The most important changes are:

**Bug Fixes:**

* Fixed an issue where the check for whether best models have been selected before was not functioning correctly. This was addressed by updating the columns checked for input changes in the `final_models` function (`R/final_models.R`, `NEWS.md`). [[1]](diffhunk://#diff-c261549c121fdfb143eebe844ce0c8f1bf21c76de5d9cf1bca5285b93ea81d2cL111-R112) [[2]](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaR63)

**Versioning and Documentation:**

* Bumped the package version to `0.6.0.9049` and updated the development version in the `DESCRIPTION` and `NEWS.md` files. [[1]](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL3-R3) [[2]](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaL1-R1)
* Added `.positai` and `.claude` to `.Rbuildignore` to ignore these files during package build.