### PR TITLE
fix tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: finnts
 Title: Microsoft Finance Time Series Forecasting Framework
-Version: 0.6.0.9049
+Version: 0.6.0.9050
 Authors@R: 
     c(person(given = "Mike",
            family = "Tokic",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# finnts 0.6.0.9049 (development version)
+# finnts 0.6.0.9050 (development version)
 
 ## Improvements
 

--- a/tests/testthat/test-best_models.R
+++ b/tests/testthat/test-best_models.R
@@ -30,7 +30,7 @@ read_fcst_file <- function(path) {
   if (ext == "parquet") {
     arrow::read_parquet(path)
   } else {
-    suppressMessages(vroom::vroom(path, show_col_types = FALSE))
+    suppressMessages(vroom::vroom(path, show_col_types = FALSE, altrep = FALSE))
   }
 }
 

--- a/tests/testthat/test-best_models.R
+++ b/tests/testthat/test-best_models.R
@@ -30,7 +30,7 @@ read_fcst_file <- function(path) {
   if (ext == "parquet") {
     arrow::read_parquet(path)
   } else {
-    suppressMessages(readr::read_csv(path, show_col_types = FALSE))
+    suppressMessages(vroom::vroom(path, show_col_types = FALSE))
   }
 }
 
@@ -39,7 +39,7 @@ write_fcst_file <- function(x, path) {
   if (ext == "parquet") {
     arrow::write_parquet(x, path)
   } else {
-    readr::write_csv(x, path)
+    vroom::vroom_write(x, path, delim = ",")
   }
 }
 


### PR DESCRIPTION
This pull request makes minor updates to the `finnts` package, primarily focused on improving file reading and writing methods in the test suite. The version number is also incremented to reflect these changes.

**Test file I/O improvements:**
* Updated the `read_fcst_file` helper in `tests/testthat/test-best_models.R` to use `vroom::vroom` instead of `readr::read_csv` for reading CSV files, which can offer better performance for large files.
* Updated the `write_fcst_file` helper in `tests/testthat/test-best_models.R` to use `vroom::vroom_write` instead of `readr::write_csv` for writing CSV files.

**Package metadata:**
* Incremented the package version to `0.6.0.9050` in `DESCRIPTION` and updated the development version in `NEWS.md`. [[1]](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL3-R3) [[2]](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaL1-R1)