### PR TITLE
Fix issue when saving global model averages in update forecast

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: finnts
 Title: Microsoft Finance Time Series Forecasting Framework
-Version: 0.6.0.9050
+Version: 0.6.0.9051
 Authors@R: 
     c(person(given = "Mike",
            family = "Tokic",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# finnts 0.6.0.9050 (development version)
+# finnts 0.6.0.9051 (development version)
 
 ## Improvements
 

--- a/R/agent_update_forecast.R
+++ b/R/agent_update_forecast.R
@@ -1700,9 +1700,29 @@ update_forecast_combo <- function(agent_info,
     suffix = "-single_models"
   )
 
-  if ("simple_average" %in% unique(final_fcst_tbl$Recipe_ID)) {
+  # filter to relevant combos for global models
+  if (combo == "All-Data") {
+    write_fcst_tbl <- final_fcst_tbl %>%
+      dplyr::filter(Combo %in% combo_list)
+  } else {
+    write_fcst_tbl <- final_fcst_tbl
+  }
+
+  if (combo == "All-Data" & prev_run_log_tbl$forecast_approach != "bottoms_up") {
+    # hierarchical: reconciliation in adjust_forecast() already replaced the data
     write_data(
-      x = final_fcst_tbl %>%
+      x = write_fcst_tbl %>%
+        convert_weekly_to_daily(project_info$date_type, prev_run_log_tbl$weekly_to_daily),
+      combo = "Best-Model",
+      run_info = new_run_info,
+      output_type = "data",
+      folder = "forecasts",
+      suffix = "-reconciled"
+    )
+  } else {
+    # bottoms_up global or local: write single models
+    write_data(
+      x = write_fcst_tbl %>%
         dplyr::filter(Recipe_ID != "simple_average") %>%
         convert_weekly_to_daily(project_info$date_type, prev_run_log_tbl$weekly_to_daily),
       combo = combo_id,
@@ -1712,50 +1732,17 @@ update_forecast_combo <- function(agent_info,
       suffix = "-single_models"
     )
 
-    write_data(
-      x = final_fcst_tbl %>%
-        dplyr::filter(Recipe_ID == "simple_average") %>%
-        convert_weekly_to_daily(project_info$date_type, prev_run_log_tbl$weekly_to_daily),
-      combo = combo_id,
-      run_info = new_run_info,
-      output_type = "data",
-      folder = "forecasts",
-      suffix = "-average_models"
-    )
-  } else if (combo == "All-Data" & prev_run_log_tbl$forecast_approach != "bottoms_up") {
-    write_data(
-      x = final_fcst_tbl %>%
-        dplyr::filter(Combo %in% combo_list) %>%
-        convert_weekly_to_daily(project_info$date_type, prev_run_log_tbl$weekly_to_daily),
-      combo = "Best-Model",
-      run_info = new_run_info,
-      output_type = "data",
-      folder = "forecasts",
-      suffix = "-reconciled"
-    )
-  } else {
-    if (combo == "All-Data") {
-      for (combo_name in combo_list) {
-        write_data(
-          x = final_fcst_tbl %>%
-            dplyr::filter(Combo == combo_name) %>%
-            convert_weekly_to_daily(project_info$date_type, prev_run_log_tbl$weekly_to_daily),
-          combo = combo_name,
-          run_info = new_run_info,
-          output_type = "data",
-          folder = "forecasts",
-          suffix = "-global_models"
-        )
-      }
-    } else {
+    # write average models if simple_average was used
+    if ("simple_average" %in% unique(write_fcst_tbl$Recipe_ID)) {
       write_data(
-        x = final_fcst_tbl %>%
+        x = write_fcst_tbl %>%
+          dplyr::filter(Recipe_ID == "simple_average") %>%
           convert_weekly_to_daily(project_info$date_type, prev_run_log_tbl$weekly_to_daily),
         combo = combo_id,
         run_info = new_run_info,
         output_type = "data",
         folder = "forecasts",
-        suffix = "-single_models"
+        suffix = "-average_models"
       )
     }
   }

--- a/R/agent_update_forecast.R
+++ b/R/agent_update_forecast.R
@@ -1719,8 +1719,37 @@ update_forecast_combo <- function(agent_info,
       folder = "forecasts",
       suffix = "-reconciled"
     )
+  } else if (combo == "All-Data") {
+    # bottoms_up global: write per-combo forecast files
+    for (combo_name in unique(write_fcst_tbl$Combo)) {
+      combo_fcst <- write_fcst_tbl %>%
+        dplyr::filter(Combo == combo_name) %>%
+        convert_weekly_to_daily(project_info$date_type, prev_run_log_tbl$weekly_to_daily)
+
+      write_data(
+        x = combo_fcst %>%
+          dplyr::filter(Recipe_ID != "simple_average"),
+        combo = combo_name,
+        run_info = new_run_info,
+        output_type = "data",
+        folder = "forecasts",
+        suffix = "-global_models"
+      )
+
+      if ("simple_average" %in% unique(combo_fcst$Recipe_ID)) {
+        write_data(
+          x = combo_fcst %>%
+            dplyr::filter(Recipe_ID == "simple_average"),
+          combo = combo_name,
+          run_info = new_run_info,
+          output_type = "data",
+          folder = "forecasts",
+          suffix = "-average_models"
+        )
+      }
+    }
   } else {
-    # bottoms_up global or local: write single models
+    # local models: write single models per combo
     write_data(
       x = write_fcst_tbl %>%
         dplyr::filter(Recipe_ID != "simple_average") %>%
@@ -1732,7 +1761,6 @@ update_forecast_combo <- function(agent_info,
       suffix = "-single_models"
     )
 
-    # write average models if simple_average was used
     if ("simple_average" %in% unique(write_fcst_tbl$Recipe_ID)) {
       write_data(
         x = write_fcst_tbl %>%


### PR DESCRIPTION
This pull request updates the package version and introduces significant improvements to the forecast writing logic for global and local models in the `update_forecast_combo` function. The changes ensure that forecast outputs are more accurately organized based on the modeling approach, particularly for global models using the "All-Data" combo.

Most important changes:

**Forecast Output Logic Improvements:**

* Refactored the `update_forecast_combo` function to differentiate how forecasts are written for global models ("All-Data" combo), including separate handling for hierarchical reconciliation and bottoms-up approaches. Now, per-combo forecast files are written for global models, with distinct suffixes for reconciled, global, and average models.

**Package Versioning:**

* Bumped the package version from `0.6.0.9050` to `0.6.0.9051` in both the `DESCRIPTION` and `NEWS.md` files to reflect these updates. [[1]](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL3-R3) [[2]](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaL1-R1)