### PR TITLE
fix boruta feature selection issues

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: finnts
 Title: Microsoft Finance Time Series Forecasting Framework
-Version: 0.6.0.9051
+Version: 0.6.0.9052
 Authors@R: 
     c(person(given = "Mike",
            family = "Tokic",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# finnts 0.6.0.9051 (development version)
+# finnts 0.6.0.9052 (development version)
 
 ## Improvements
 

--- a/R/feature_selection.R
+++ b/R/feature_selection.R
@@ -38,6 +38,14 @@ run_feature_selection <- function(input_data,
       dplyr::select(-Target_Original)
   }
 
+  # drop raw external regressor copies (kept only for foundation models and
+  # removed before standard model training); they can contain NA values that
+  # break feature selection routines like Boruta
+  if (any(grepl("_original$", colnames(input_data)))) {
+    input_data <- input_data %>%
+      dplyr::select(-tidyselect::ends_with("_original"))
+  }
+
   # check for multiple time series
   if (length(unique(input_data$Combo)) > 1) {
     global <- TRUE


### PR DESCRIPTION
This pull request updates the `finnts` package to version 0.6.0.9052 and introduces an important improvement to the feature selection process. The main change ensures that raw external regressor columns, which may contain missing values and are only needed for foundation models, are removed before running feature selection. This prevents errors in routines like Boruta that cannot handle missing values.

Feature selection improvements:
* In `R/feature_selection.R`, the function `run_feature_selection` now drops columns ending with `_original` before feature selection, avoiding issues with NA values in those columns.

Version and documentation updates:
* Bumped the package version to 0.6.0.9052 in `DESCRIPTION`.
* Updated the development version in `NEWS.md`.