### PR TITLE
Mitokic/06292026/subscript bug fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: finnts
 Title: Microsoft Finance Time Series Forecasting Framework
-Version: 0.6.0.9052
+Version: 0.6.0.9053
 Authors@R: 
     c(person(given = "Mike",
            family = "Tokic",

--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,7 @@
 
 ## Bug Fixes
 
+-   Fixed `subscript out of bounds` failures for time series combos containing non-ASCII characters. File name hashes are now stable regardless of how the text was read in (e.g. `read.csv` vs `vroom`), so input data, EDA, and forecast outputs resolve to the same file.
 -   Fixed partial-fold models incorrectly winning Best_Model selection. Models that fail on some back-test folds are now excluded from best-model ranking while other complete models continue normally.
 -   Fixed `null_converter()` crash in agent workflow when input is `NA`.
 -   Added retry with exponential backoff (up to 3 retries) for Chronos and TimesFM API calls on transient failures (HTTP 429, 5xx, connection errors).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# finnts 0.6.0.9052 (development version)
+# finnts 0.6.0.9053 (development version)
 
 ## Improvements
 

--- a/R/read_write_data.R
+++ b/R/read_write_data.R
@@ -342,6 +342,14 @@ get_prepped_models <- function(run_info) {
 #' @return hashed value
 #' @noRd
 hash_data <- function(x) {
+  # normalize the string encoding marker so identical bytes hash the same
+  # regardless of how the text was read (e.g. read.csv marks combos as
+  # "unknown" while vroom marks them "UTF-8"), which otherwise produces
+  # different digests for non-ASCII combo names and breaks file lookups
+  if (is.character(x)) {
+    Encoding(x) <- "unknown"
+  }
+
   digest::digest(object = x, algo = "xxhash64")
 }
 

--- a/tests/testthat/test-hash_data.R
+++ b/tests/testthat/test-hash_data.R
@@ -1,0 +1,91 @@
+# tests/testthat/test-hash_data.R
+# Regression tests for hash_data() encoding stability.
+#
+# Bug: digest::digest() is sensitive to the R string Encoding marker, so a
+# non-ASCII combo read with read.csv (marker "unknown") hashed differently than
+# the same bytes read with vroom (marker "UTF-8"). Input files were named with
+# one hash but looked up with the other, causing "subscript out of bounds" in
+# read_file(). hash_data() now normalizes the marker before hashing.
+
+# helper: build a string with given bytes and a specific Encoding marker
+make_str <- function(bytes, encoding) {
+  s <- rawToChar(as.raw(bytes))
+  Encoding(s) <- encoding
+  s
+}
+
+# "Karén" in UTF-8 bytes (é = 0xC3 0xA9)
+karen_bytes <- c(0x4b, 0x61, 0x72, 0xc3, 0xa9, 0x6e)
+
+test_that("hash_data is stable across encoding markers for identical bytes", {
+  combo_unknown <- make_str(karen_bytes, "unknown") # as read.csv reads it
+  combo_utf8 <- make_str(karen_bytes, "UTF-8") # as vroom reads it
+  combo_latin1 <- make_str(karen_bytes, "latin1")
+
+  expect_identical(charToRaw(combo_unknown), charToRaw(combo_utf8))
+  expect_equal(hash_data(combo_unknown), hash_data(combo_utf8))
+  expect_equal(hash_data(combo_unknown), hash_data(combo_latin1))
+})
+
+test_that("hash_data keeps ASCII hashes unchanged (backward compatible file names)", {
+  # these values must never change or existing run-logging files break
+  expect_equal(hash_data("finn_forecast"), "2b8cd41e44e9eb3e")
+  expect_equal(hash_data("all"), "5ec4d53eb467796e")
+  expect_equal(hash_data("Microsoft AI--Rukmini I. (Ads)"), "025f819e516b2de2")
+})
+
+test_that("hash_data leaves non-character input untouched", {
+  df <- data.frame(a = 1:2, b = c("x", "y"))
+  expect_equal(
+    hash_data(df),
+    digest::digest(object = df, algo = "xxhash64")
+  )
+  expect_equal(hash_data(42L), digest::digest(object = 42L, algo = "xxhash64"))
+})
+
+test_that("non-ASCII combo file written via read.csv path is found via vroom path", {
+  tmp <- withr::local_tempdir()
+
+  project_info <- list(
+    project_name = "verify_proj",
+    storage_object = NULL,
+    path = tmp,
+    data_output = "csv",
+    object_output = "rds",
+    run_name = "runABC"
+  )
+
+  # combo as it arrives from read.csv of the user's data (marker "unknown")
+  combo_written <- make_str(karen_bytes, "unknown")
+
+  # write the input file exactly like set_agent_info() does
+  write_data(
+    x = data.frame(Combo = combo_written, Date = as.Date("2024-01-01"), Target = 10),
+    combo = combo_written,
+    run_info = project_info,
+    output_type = "data",
+    folder = "input_data",
+    suffix = NULL
+  )
+
+  # combo as it is re-read at runtime via read_file()/vroom (marker "UTF-8")
+  combo_runtime <- make_str(karen_bytes, "UTF-8")
+
+  # build the per-combo lookup exactly like submit_fcst_run()
+  lookup_glob <- paste0(
+    project_info$path, "/input_data/*", hash_data(project_info$project_name), "-",
+    hash_data(project_info$run_name), "-", hash_data(combo_runtime), ".",
+    project_info$data_output
+  )
+
+  found <- list_files(NULL, lookup_glob)
+  expect_length(found, 1)
+
+  result <- read_file(
+    run_info = project_info,
+    file_list = found,
+    return_type = "df"
+  )
+  expect_equal(nrow(result), 1)
+  expect_equal(result$Target, 10)
+})


### PR DESCRIPTION
This pull request addresses a bug where time series combos containing non-ASCII characters could cause "subscript out of bounds" errors due to inconsistent file name hashing, depending on how the text was read (e.g., `read.csv` vs `vroom`). The update ensures that file name hashes are stable and consistent across different string encoding markers, improving reliability for input data, EDA, and forecast outputs. It also adds comprehensive regression tests to prevent similar issues in the future.

**Bug Fixes and Reliability Improvements:**

* Updated the `hash_data` function in `R/read_write_data.R` to normalize the encoding marker of character strings before hashing, ensuring that identical bytes produce the same hash regardless of their encoding marker (e.g., "unknown" vs "UTF-8"). This resolves file lookup failures for non-ASCII combo names.
* Documented the bug fix in `NEWS.md`, describing the resolution of `subscript out of bounds` errors for time series combos with non-ASCII characters and the stabilization of file name hashes.

**Testing and Backward Compatibility:**

* Added a new test file `tests/testthat/test-hash_data.R` with regression tests to verify that `hash_data` is stable across encoding markers, preserves backward compatibility for ASCII hashes, and works correctly with non-character inputs and real file I/O scenarios.

**Versioning and Documentation:**

* Bumped the package version to `0.6.0.9053` in `DESCRIPTION` and updated the development version in `NEWS.md`. [[1]](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL3-R3) [[2]](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaL1-R1)