### PR TITLE
[repo-improver] test-coverage: cover check_input_data validation error branches

### DIFF
--- a/tests/testthat/test-input_checks.R
+++ b/tests/testthat/test-input_checks.R
@@ -269,11 +269,7 @@ test_that("check_input_data rejects uneven day-of-month spacing for month data",
 
 test_that("check_input_data does not apply day-of-month spacing check to week data", {
   data_uneven <- valid_data
-  data_uneven$Date <- as.Date(c(
-    "2020-01-01", "2020-02-02", "2020-03-03", "2020-04-04",
-    "2020-05-05", "2020-06-06", "2020-07-07", "2020-08-08",
-    "2020-09-09", "2020-10-10", "2020-11-11", "2020-12-12"
-  ))
+  data_uneven$Date <- seq.Date(as.Date("2020-01-01"), by = "week", length.out = 12)
   expect_no_error(
     check_input_data(
       input_data = data_uneven,

--- a/tests/testthat/test-input_checks.R
+++ b/tests/testthat/test-input_checks.R
@@ -142,6 +142,199 @@ test_that("check_input_data rejects date-formatted combo variable", {
   )
 })
 
+# * Missing combo / target / external regressor columns ----
+
+test_that("check_input_data rejects combo variables missing from input data", {
+  expect_error(
+    check_input_data(
+      input_data = valid_data,
+      combo_variables = c("missing_combo"),
+      target_variable = "value",
+      external_regressors = NULL,
+      date_type = "month",
+      fiscal_year_start = 1,
+      parallel_processing = NULL
+    ),
+    "combo variables do not match column headers.*Missing columns: missing_combo"
+  )
+})
+
+test_that("check_input_data rejects a target variable missing from input data", {
+  expect_error(
+    check_input_data(
+      input_data = valid_data,
+      combo_variables = c("id"),
+      target_variable = "missing_target",
+      external_regressors = NULL,
+      date_type = "month",
+      fiscal_year_start = 1,
+      parallel_processing = NULL
+    ),
+    "target variable 'missing_target' does not match a column header"
+  )
+})
+
+test_that("check_input_data rejects external regressors missing from input data", {
+  expect_error(
+    check_input_data(
+      input_data = valid_data,
+      combo_variables = c("id"),
+      target_variable = "value",
+      external_regressors = c("missing_xreg"),
+      date_type = "month",
+      fiscal_year_start = 1,
+      parallel_processing = NULL
+    ),
+    "external regressors do not match column headers.*Missing columns: missing_xreg"
+  )
+})
+
+# * Non-numeric target variable ----
+
+test_that("check_input_data rejects a non-numeric target variable", {
+  data_char_target <- valid_data
+  data_char_target$value <- as.character(data_char_target$value)
+  expect_error(
+    check_input_data(
+      input_data = data_char_target,
+      combo_variables = c("id"),
+      target_variable = "value",
+      external_regressors = NULL,
+      date_type = "month",
+      fiscal_year_start = 1,
+      parallel_processing = NULL
+    ),
+    "Target variable in input data needs to be numeric"
+  )
+})
+
+# * Date column presence and formatting ----
+
+test_that("check_input_data requires a column named 'Date'", {
+  data_no_date <- valid_data
+  names(data_no_date)[names(data_no_date) == "Date"] <- "when"
+  expect_error(
+    check_input_data(
+      input_data = data_no_date,
+      combo_variables = c("id"),
+      target_variable = "value",
+      external_regressors = NULL,
+      date_type = "month",
+      fiscal_year_start = 1,
+      parallel_processing = NULL
+    ),
+    "date column in input data needs to be named as 'Date'"
+  )
+})
+
+test_that("check_input_data requires the 'Date' column to be date-formatted", {
+  data_bad_date <- valid_data
+  data_bad_date$Date <- as.character(data_bad_date$Date)
+  expect_error(
+    check_input_data(
+      input_data = data_bad_date,
+      combo_variables = c("id"),
+      target_variable = "value",
+      external_regressors = NULL,
+      date_type = "month",
+      fiscal_year_start = 1,
+      parallel_processing = NULL
+    ),
+    "date column in input data needs to be formatted as a date value"
+  )
+})
+
+# * Even day-of-month spacing for month/quarter/year data ----
+
+test_that("check_input_data rejects uneven day-of-month spacing for month data", {
+  data_uneven <- valid_data
+  data_uneven$Date <- as.Date(c(
+    "2020-01-01", "2020-02-02", "2020-03-03", "2020-04-04",
+    "2020-05-05", "2020-06-06", "2020-07-07", "2020-08-08",
+    "2020-09-09", "2020-10-10", "2020-11-11", "2020-12-12"
+  ))
+  expect_error(
+    check_input_data(
+      input_data = data_uneven,
+      combo_variables = c("id"),
+      target_variable = "value",
+      external_regressors = NULL,
+      date_type = "month",
+      fiscal_year_start = 1,
+      parallel_processing = NULL
+    ),
+    "historical date values are not evenly spaced.*day of the month"
+  )
+})
+
+test_that("check_input_data does not apply day-of-month spacing check to week data", {
+  data_uneven <- valid_data
+  data_uneven$Date <- as.Date(c(
+    "2020-01-01", "2020-02-02", "2020-03-03", "2020-04-04",
+    "2020-05-05", "2020-06-06", "2020-07-07", "2020-08-08",
+    "2020-09-09", "2020-10-10", "2020-11-11", "2020-12-12"
+  ))
+  expect_no_error(
+    check_input_data(
+      input_data = data_uneven,
+      combo_variables = c("id"),
+      target_variable = "value",
+      external_regressors = NULL,
+      date_type = "week",
+      fiscal_year_start = 1,
+      parallel_processing = NULL
+    )
+  )
+})
+
+# * fiscal_year_start range ----
+
+test_that("check_input_data rejects fiscal_year_start outside 1-12", {
+  expect_error(
+    check_input_data(
+      input_data = valid_data,
+      combo_variables = c("id"),
+      target_variable = "value",
+      external_regressors = NULL,
+      date_type = "month",
+      fiscal_year_start = 13,
+      parallel_processing = NULL
+    ),
+    "fiscal year start should be a number from 1 to 12"
+  )
+
+  expect_error(
+    check_input_data(
+      input_data = valid_data,
+      combo_variables = c("id"),
+      target_variable = "value",
+      external_regressors = NULL,
+      date_type = "month",
+      fiscal_year_start = 0,
+      parallel_processing = NULL
+    ),
+    "fiscal year start should be a number from 1 to 12"
+  )
+})
+
+# * Duplicate combo-Date rows ----
+
+test_that("check_input_data rejects duplicate combo-Date rows", {
+  data_dup <- rbind(valid_data, valid_data[1, ])
+  expect_error(
+    check_input_data(
+      input_data = data_dup,
+      combo_variables = c("id"),
+      target_variable = "value",
+      external_regressors = NULL,
+      date_type = "month",
+      fiscal_year_start = 1,
+      parallel_processing = NULL
+    ),
+    "duplicate rows have been detected in the input data"
+  )
+})
+
 # * Test set_run_info input change detection ----
 
 test_that("set_run_info error lists changed inputs", {


### PR DESCRIPTION
## Evidence

`R/input_checks.R::check_input_data()` contains a number of detailed, user-facing
validation error messages (several recently enhanced) that had no regression
coverage in `tests/testthat/test-input_checks.R`. A baseline reproducer confirmed
the exact current message for each branch, so the behavior is well-defined but
unguarded against accidental regressions.

## Change

Add focused `testthat` coverage for the previously untested `check_input_data`
validation branches. No source behavior is changed — this is test-only:

- combo variables missing from the input data
- target variable missing from the input data
- external regressors missing from the input data
- non-numeric target variable
- missing `Date` column
- non-date-formatted `Date` column
- uneven day-of-month spacing for `month` data, plus a positive test that
  `date_type = "week"` bypasses that check
- `fiscal_year_start` outside 1–12
- duplicate combo-`Date` rows

## Dependency decision

No new dependency added. Existing capabilities were sufficient: `testthat`
(already in `Suggests`) and base R. This is test-only coverage, so the dependency
ladder resolves at step 2 (existing declared dependencies).

## Validation

Each category was run in its own process with
`Rscript -e "devtools::test(filter = '<filter>', stop_on_failure = TRUE)"`,
affected category first:

| Category | Filter | Result |
|---|---|---|
| focused reproducer | `^input_checks$` | FAIL 0 · PASS 39 |
| data-input-preparation | `^(input_checks\|hash_data\|prep_data\|clamp_negative_target\|undifference)$` | FAIL 0 · PASS 262 |
| forecasting-core | `^(forecast_time_series\|multistep\|hierarchical)$` | FAIL 0 · PASS 237 |
| model-selection-results | `^(best_models\|final_models\|summarize_models)$` | FAIL 0 · SKIP 2 · PASS 700 |
| agent-run-lifecycle | `^(agent\|finalize_run\|load_run_results)$` | FAIL 0 · PASS 155 |
| foundation-model-integrations | `^(foundation-model-credentials\|chronos\|timegpt\|timesfm)$` | FAIL 0 · SKIP 17 · PASS 281 |

All 18 `test-*.R` files map exactly to the five configured categories; no
unclassified files. No roxygen/source changes, so `devtools::document()` was not
required.

`Rscript -e "devtools::check(args = '--no-tests')"` completed all package checks
but errored only at vignette re-building (`'xfun::attr()' is deprecated`). This is
a pre-existing environment/toolchain limitation: the identical command on clean
`main` fails at the same vignette step with the same error, so it is unrelated to
this test-only change. All focused and category tests pass.

## Risk and limitations

Blast radius 1 (test-only; no runtime or public-API change). These tests lock in
the current user-facing validation messages, so intentional future message edits
must update the corresponding assertions. The only unavailable gate is the
pre-existing vignette build error noted above.

## Automation metadata
- Scout run: 2026-08-03 18:22 PDT (America/Los_Angeles)
- Source SHA: `53908f7d75ea2f37ccf269afada8bc62e99bc5c7`
- Recommendation fingerprint: `82eda7658e3d9c96cbfdb0c1b913ca8671b273281591527a139b1ccb2bdd6c77`

<!-- finnts-repo-improver -->
<!-- recommendation-fingerprint: 82eda7658e3d9c96cbfdb0c1b913ca8671b273281591527a139b1ccb2bdd6c77 -->
