### PR TITLE
Mitokic/09082026/list files bug fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,13 @@ On Windows, when `R` or `Rscript` is not on `PATH`, use `./tools/run-r.ps1 -Expr
 
 Keep edits focused. Do not refactor unrelated code, change public APIs without approval, or overwrite user changes in a dirty worktree.
 
+## Artifact I/O
+
+- Prefer direct reads of deterministic artifact paths over `list_files()` or wildcard directory enumeration whenever the project, run, combo, recipe, and artifact suffix are already known. This is especially important during per-series iteration and training against large ADLS-backed logging and artifact folders.
+- Do not list a directory merely to locate or check the existence of a known file. Reuse the storage abstraction's exact-path read/download support; distinguish a genuinely missing optional artifact from authentication, storage, and deserialization failures.
+- Keep listings for genuine discovery of unknown artifact names. When discovery is necessary, perform it once in the coordinating workflow and reuse the resulting paths or metadata across loops and workers where safe. Avoid repeated per-series, per-model, or per-retry listings and stale cross-run caches.
+- Preserve supported storage backends, output formats, restart behavior, and required-artifact errors. Add focused tests that reject unexpected directory enumeration on known-path workflows and verify unchanged results; do not trade fewer listings for redundant downloads or reads.
+
 ## Documentation Boundaries
 
 - Keep `AGENTS.md`, `CLAUDE.md`, and applicable scoped rules synchronized when engineering practices change, without repeating the same detailed rule in multiple files.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: finnts
 Title: Microsoft Finance Time Series Forecasting Framework
-Version: 0.7.0.9004
+Version: 0.7.0.9005
 Authors@R: 
     c(person(given = "Mike",
            family = "Tokic",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
-# finnts 0.7.0.9004 (DEVELOPMENT VERSION)
+# finnts 0.7.0.9005 (DEVELOPMENT VERSION)
 
 ## Bug Fixes
 
+-   Local and ADLS-mounted workflows now read known series inputs, recipes, EDA results, model outputs, and completion artifacts by exact path. Necessary directory listings are reused during model preparation, EDA aggregation, and condensed forecast reads. Standalone forecast getters discover unknown condensed batches once and preserve their precedence even when the first batch is absent. Exact-file validation is not repeated before reading, and local CSV read-time metadata and I/O failures propagate instead of becoming empty or partial results. Valid empty CSV files and optional missing artifacts retain their supported behavior. Default legacy reads, remote-provider downloads, and Spark data-frame routing are unchanged.
 -   `update_forecast()` now excludes predecessor time series that are absent from the current input before global or local update routing. Removed series no longer produce empty-schema or missing-artifact fallback errors, while current-only series continue to receive default local forecasts.
 -   Global Agent iterations now use hierarchy choices that match the outer optimization scope. Bottom-level runs may compare `bottoms_up` with the exact standard or grouped hierarchy detected by EDA after reconciliation to bottom-level series. Runs whose input was already expanded to hierarchy-level `ID` series use `bottoms_up` for every inner global and local iteration before one final outer reconciliation.
 -   `iterate_forecast()` now skips repeated global optimization when any current-run best result was already finalized at the requested iteration target, then resumes only unfinished local series. Incomplete metadata and higher iteration targets retain the existing global retry behavior.

--- a/R/agent_eda.R
+++ b/R/agent_eda.R
@@ -69,7 +69,6 @@ save_eda_data <- function(agent_info) {
   local_eda <- is.null(project_info$storage_object) &&
     project_info$data_output %in% c("csv", "parquet", "rds")
   eda_inventory <- if (local_eda) local_artifact_inventory(project_info, "eda") else NULL
-  if (!local_eda) get_total_combos(agent_info)
 
   # 1. Data Profile
   tryCatch(

--- a/R/agent_eda.R
+++ b/R/agent_eda.R
@@ -66,7 +66,10 @@ save_eda_data <- function(agent_info) {
 
   # Always get all combos
   combo_value <- "*"
-  combo_list <- get_total_combos(agent_info)
+  local_eda <- is.null(project_info$storage_object) &&
+    project_info$data_output %in% c("csv", "parquet", "rds")
+  eda_inventory <- if (local_eda) local_artifact_inventory(project_info, "eda") else NULL
+  if (!local_eda) get_total_combos(agent_info)
 
   # 1. Data Profile
   tryCatch(
@@ -104,7 +107,9 @@ save_eda_data <- function(agent_info) {
   # 2. ACF Results
   tryCatch(
     {
-      acf_files <- list_files(
+      acf_files <- if (local_eda) {
+        eda_inventory[endsWith(eda_inventory, paste0("-acf.", project_info$data_output))]
+      } else list_files(
         project_info$storage_object,
         paste0(
           project_info$path, "/eda/*", hash_data(project_info$project_name), "-",
@@ -138,7 +143,9 @@ save_eda_data <- function(agent_info) {
   # 3. PACF Results
   tryCatch(
     {
-      pacf_files <- list_files(
+      pacf_files <- if (local_eda) {
+        eda_inventory[endsWith(eda_inventory, paste0("-pacf.", project_info$data_output))]
+      } else list_files(
         project_info$storage_object,
         paste0(
           project_info$path, "/eda/*", hash_data(project_info$project_name), "-",
@@ -172,7 +179,9 @@ save_eda_data <- function(agent_info) {
   # 4. Stationarity Results
   tryCatch(
     {
-      stat_files <- list_files(
+      stat_files <- if (local_eda) {
+        eda_inventory[endsWith(eda_inventory, paste0("-stationarity.", project_info$data_output))]
+      } else list_files(
         project_info$storage_object,
         paste0(
           project_info$path, "/eda/*", hash_data(project_info$project_name), "-",
@@ -208,7 +217,9 @@ save_eda_data <- function(agent_info) {
   # 5. Missing Data Results
   tryCatch(
     {
-      miss_files <- list_files(
+      miss_files <- if (local_eda) {
+        eda_inventory[endsWith(eda_inventory, paste0("-missing.", project_info$data_output))]
+      } else list_files(
         project_info$storage_object,
         paste0(
           project_info$path, "/eda/*", hash_data(project_info$project_name), "-",
@@ -246,7 +257,9 @@ save_eda_data <- function(agent_info) {
   # 6. Outlier Results
   tryCatch(
     {
-      outlier_files <- list_files(
+      outlier_files <- if (local_eda) {
+        eda_inventory[endsWith(eda_inventory, paste0("-outliers.", project_info$data_output))]
+      } else list_files(
         project_info$storage_object,
         paste0(
           project_info$path, "/eda/*", hash_data(project_info$project_name), "-",
@@ -292,7 +305,9 @@ save_eda_data <- function(agent_info) {
   # 7. Additional Seasonality Results
   tryCatch(
     {
-      season_files <- list_files(
+      season_files <- if (local_eda) {
+        eda_inventory[endsWith(eda_inventory, paste0("-add_season.", project_info$data_output))]
+      } else list_files(
         project_info$storage_object,
         paste0(
           project_info$path, "/eda/*", hash_data(project_info$project_name), "-",
@@ -353,7 +368,9 @@ save_eda_data <- function(agent_info) {
   if (!is.null(agent_info$external_regressors)) {
     tryCatch(
       {
-        xreg_files <- list_files(
+        xreg_files <- if (local_eda) {
+          eda_inventory[endsWith(eda_inventory, paste0("-xreg_scan.", project_info$data_output))]
+        } else list_files(
           project_info$storage_object,
           paste0(
             project_info$path, "/eda/*", hash_data(project_info$project_name), "-",
@@ -557,6 +574,18 @@ load_eda_results <- function(agent_info,
   # get project info
   project_info <- agent_info$project_info
   project_info$run_name <- agent_info$run_id
+  local_reads <- is.null(project_info$storage_object) &&
+    project_info$data_output %in% c("csv", "parquet", "rds")
+  eda_inventory <- if (local_reads && is.null(combo)) {
+    local_artifact_inventory(project_info, "eda")
+  } else NULL
+  scan_paths <- function(suffix) {
+    if (is.null(combo)) {
+      eda_inventory[endsWith(eda_inventory, paste0(suffix, ".", project_info$data_output))]
+    } else {
+      local_artifact_path(project_info, "eda", suffix, combo)
+    }
+  }
 
   # read all combos or just one
   if (is.null(combo)) {
@@ -601,14 +630,17 @@ load_eda_results <- function(agent_info,
   # acf scan
   acf_scan <- read_file(
     run_info = project_info,
-    file_list = list_files(
+    file_list = if (local_reads) local_artifact_files(
+      scan_paths("-acf")
+    ) else list_files(
       project_info$storage_object,
       paste0(
         project_info$path, "/eda/*", hash_data(project_info$project_name), "-",
         hash_data(agent_info$run_id), "-", combo_value, "-acf.", project_info$data_output
       )
     ),
-    return_type = "df"
+    return_type = "df",
+    strict = local_reads
   ) %>%
     dplyr::mutate(Value = as.numeric(Value))
 
@@ -637,14 +669,17 @@ load_eda_results <- function(agent_info,
   # pacf scan
   pacf_scan <- read_file(
     run_info = project_info,
-    file_list = list_files(
+    file_list = if (local_reads) local_artifact_files(
+      scan_paths("-pacf")
+    ) else list_files(
       project_info$storage_object,
       paste0(
         project_info$path, "/eda/*", hash_data(project_info$project_name), "-",
         hash_data(agent_info$run_id), "-", combo_value, "-pacf.", project_info$data_output
       )
     ),
-    return_type = "df"
+    return_type = "df",
+    strict = local_reads
   ) %>%
     dplyr::mutate(Value = as.numeric(Value))
 
@@ -673,14 +708,17 @@ load_eda_results <- function(agent_info,
   # stationarity scan
   stationarity_scan <- read_file(
     run_info = project_info,
-    file_list = list_files(
+    file_list = if (local_reads) local_artifact_files(
+      scan_paths("-stationarity")
+    ) else list_files(
       project_info$storage_object,
       paste0(
         project_info$path, "/eda/*", hash_data(project_info$project_name), "-",
         hash_data(agent_info$run_id), "-", combo_value, "-stationarity.", project_info$data_output
       )
     ),
-    return_type = "df"
+    return_type = "df",
+    strict = local_reads
   )
 
   if (is.null(combo)) {
@@ -705,14 +743,17 @@ load_eda_results <- function(agent_info,
   # missing data scan
   missing_scan <- read_file(
     run_info = project_info,
-    file_list = list_files(
+    file_list = if (local_reads) local_artifact_files(
+      scan_paths("-missing")
+    ) else list_files(
       project_info$storage_object,
       paste0(
         project_info$path, "/eda/*", hash_data(project_info$project_name), "-",
         hash_data(agent_info$run_id), "-", combo_value, "-missing.", project_info$data_output
       )
     ),
-    return_type = "df"
+    return_type = "df",
+    strict = local_reads
   )
 
   if (is.null(combo)) {
@@ -736,14 +777,17 @@ load_eda_results <- function(agent_info,
   # outlier scan
   outlier_scan <- read_file(
     run_info = project_info,
-    file_list = list_files(
+    file_list = if (local_reads) local_artifact_files(
+      scan_paths("-outliers")
+    ) else list_files(
       project_info$storage_object,
       paste0(
         project_info$path, "/eda/*", hash_data(project_info$project_name), "-",
         hash_data(agent_info$run_id), "-", combo_value, "-outliers.", project_info$data_output
       )
     ),
-    return_type = "df"
+    return_type = "df",
+    strict = local_reads
   )
 
   outlier_scan <- summarize_outlier_scan(outlier_scan)
@@ -768,14 +812,17 @@ load_eda_results <- function(agent_info,
   # seasonality scan
   seasonality_scan <- read_file(
     run_info = project_info,
-    file_list = list_files(
+    file_list = if (local_reads) local_artifact_files(
+      scan_paths("-add_season")
+    ) else list_files(
       project_info$storage_object,
       paste0(
         project_info$path, "/eda/*", hash_data(project_info$project_name), "-",
         hash_data(agent_info$run_id), "-", combo_value, "-add_season.", project_info$data_output
       )
     ),
-    return_type = "df"
+    return_type = "df",
+    strict = local_reads
   ) %>%
     dplyr::mutate(Value = as.numeric(Value))
 
@@ -828,14 +875,17 @@ load_eda_results <- function(agent_info,
   } else {
     xreg_scan <- read_file(
       run_info = project_info,
-      file_list = list_files(
+      file_list = if (local_reads) local_artifact_files(
+        scan_paths("-xreg_scan")
+      ) else list_files(
         project_info$storage_object,
         paste0(
           project_info$path, "/eda/*", hash_data(project_info$project_name), "-",
           hash_data(agent_info$run_id), "-", combo_value, "-xreg_scan.", project_info$data_output
         )
       ),
-      return_type = "df"
+      return_type = "df",
+      strict = local_reads
     )
 
     if (is.null(combo)) {
@@ -895,7 +945,13 @@ data_profile <- function(agent_info) {
   hist_end_date <- agent_info$hist_end_date
 
   # check if profiling has already been done
-  profile_list <- tryCatch(
+  profile_list <- if (is.null(project_info$storage_object) &&
+    identical(project_info$object_output, "rds")) {
+    read_local_artifacts(project_info,
+      local_artifact_path(project_info, "eda", "-data_profile", extension = "rds"),
+      return_type = "object", allow_missing = TRUE
+    )
+  } else tryCatch(
     read_file(project_info,
       path = paste0(
         "eda/*", hash_data(project_info$project_name), "-",
@@ -1710,7 +1766,13 @@ hierarchy_detect <- function(agent_info,
 
   if (is.null(input_data)) {
     # check if hierarchy detection has already been done
-    hier_list <- tryCatch(
+    hier_list <- if (is.null(project_info$storage_object) &&
+      identical(project_info$object_output, "rds")) {
+      read_local_artifacts(project_info,
+        local_artifact_path(project_info, "eda", "-hierarchy", extension = "rds"),
+        return_type = "object", allow_missing = TRUE
+      )
+    } else tryCatch(
       read_file(project_info,
         path = paste0(
           "eda/*", hash_data(project_info$project_name), "-",
@@ -2029,13 +2091,20 @@ resolve_combo_hashes <- function(agent_info, combo_hashes) {
   project_info$run_name <- agent_info$run_id
 
   # list input data files for this agent run
-  input_files <- list_files(
+  input_file_list <- if (is.null(project_info$storage_object) &&
+    project_info$data_output %in% c("csv", "parquet", "rds")) {
+    local_artifact_files(
+      local_artifact_path(project_info, "input_data", combo = sort(unique(combo_hashes))),
+      allow_missing = TRUE
+    )
+  } else list_files(
     project_info$storage_object,
     paste0(
       project_info$path, "/input_data/*", hash_data(project_info$project_name), "-",
       hash_data(agent_info$run_id), "*.", project_info$data_output
     )
-  ) %>%
+  )
+  input_files <- input_file_list %>%
     tibble::tibble(
       Path = .
     ) %>%

--- a/R/agent_iterate_forecast.R
+++ b/R/agent_iterate_forecast.R
@@ -2099,7 +2099,14 @@ submit_fcst_run <- function(agent_info,
   }
 
   # get input data
-  input_data <- read_file(
+  input_data <- if (!is.null(combo) && is.null(project_info$storage_object) &&
+    project_info$data_output %in% c("csv", "parquet", "rds")) {
+    input_info <- project_info
+    input_info$run_name <- agent_info$run_id
+    read_local_artifacts(input_info,
+      local_artifact_path(input_info, "input_data", combo = combo)
+    )
+  } else read_file(
     run_info = project_info,
     file_list = list_files(
       project_info$storage_object,
@@ -2589,7 +2596,15 @@ log_best_run <- function(agent_info,
     }
 
     # verify that all expected agent_best_run files exist
-    if (combo == "all") {
+    if (combo == "all" && is.null(project_info$storage_object)) {
+      expected_files <- local_artifact_files(local_artifact_path(
+        project_info, "logs", "-agent_best_run",
+        combo = purrr::map_chr(combo_list, hash_data), extension = "csv"
+      ), allow_missing = TRUE)
+      existing_count <- sum(vapply(expected_files, function(path) {
+        as.integer(nrow(read_file(project_info, file_list = path, strict = TRUE)) > 0L)
+      }, integer(1)))
+    } else if (combo == "all") {
       # global model: use list_files since multiple combos are involved
       existing_best_run_files <- list_files(
         project_info$storage_object,

--- a/R/agent_summarize_models.R
+++ b/R/agent_summarize_models.R
@@ -424,7 +424,13 @@ summarize_models <- function(agent_info,
     hash_data(project_info$run_name), "*-model_summary.", project_info$data_output
   )
 
-  summary_results <- read_file(
+  summary_results <- if (is.null(project_info$storage_object) &&
+    project_info$data_output %in% c("csv", "parquet", "rds")) {
+    read_local_artifacts(project_info, local_artifact_path(
+      project_info, "models", "-model_summary",
+      combo = purrr::map_chr(best_run_tbl$combo, hash_data)
+    ))
+  } else read_file(
     run_info = project_info,
     path = model_summary_path,
     return_type = "df"

--- a/R/agent_update_forecast.R
+++ b/R/agent_update_forecast.R
@@ -1196,7 +1196,16 @@ reconcile_agent_forecast <- function(agent_info,
 
   run_name <- single_run$best_run_name
 
-  train_test_file <- list_files(
+  train_test_file <- if (is.null(project_info$storage_object) &&
+    project_info$data_output %in% c("csv", "parquet", "rds")) {
+    selected_run_info <- project_info
+    selected_run_info$project_name <- project_name
+    selected_run_info$run_name <- run_name
+    local_artifact_files(
+      local_artifact_path(selected_run_info, "prep_models", "-train_test_split"),
+      allow_missing = TRUE
+    )
+  } else list_files(
     project_info$storage_object,
     paste0(
       project_info$path, "/prep_models/*", hash_data(project_name), "-",
@@ -1213,7 +1222,8 @@ reconcile_agent_forecast <- function(agent_info,
   model_train_test_tbl <- read_file(
     run_info = project_info,
     file_list = train_test_file[1],
-    return_type = "df"
+    return_type = "df",
+    strict = is.null(project_info$storage_object)
   )
 
   # load hierarchical forecast

--- a/R/ensemble_models.R
+++ b/R/ensemble_models.R
@@ -81,13 +81,17 @@ ensemble_models <- function(run_info,
   run_local_models <- log_df$run_local_models
   models_to_run <- log_df$models_to_run
   models_not_to_run <- log_df$models_not_to_run
+  local_combo <- is.null(run_info$storage_object) && length(run_info$combo) == 1L &&
+    run_info$data_output %in% c("csv", "parquet", "rds")
 
   if (log_df$run_ensemble_models == FALSE) {
     cli::cli_alert_info("Ensemble models have been turned off.")
     return(cli::cli_progress_done())
   }
 
-  combo_list <- list_files(
+  combo_list <- if (local_combo) {
+    run_info$combo
+  } else list_files(
     run_info$storage_object,
     paste0(
       run_info$path, "/forecasts/*", hash_data(run_info$project_name), "-",
@@ -112,7 +116,13 @@ ensemble_models <- function(run_info,
   )
 
   # check if a previous run already has necessary outputs
-  prev_combo_list <- list_files(
+  prev_combo_list <- if (local_combo) {
+    existing <- local_artifact_files(
+      local_artifact_path(run_info, "forecasts", "-ensemble_models", run_info$combo),
+      allow_missing = TRUE
+    )
+    if (length(existing) > 0L) run_info$combo else character()
+  } else list_files(
     run_info$storage_object,
     paste0(
       run_info$path, "/forecasts/*", hash_data(run_info$project_name), "-",
@@ -489,7 +499,12 @@ ensemble_models <- function(run_info,
   par_end(cl)
 
   # check if all time series combos ran correctly
-  successful_combos <- list_files(
+  successful_combos <- if (local_combo) {
+    length(local_artifact_files(
+      local_artifact_path(run_info, "forecasts", "-ensemble_models", run_info$combo),
+      allow_missing = TRUE
+    ))
+  } else list_files(
     run_info$storage_object,
     paste0(
       run_info$path, "/forecasts/*", hash_data(run_info$project_name), "-",

--- a/R/final_models.R
+++ b/R/final_models.R
@@ -99,6 +99,8 @@ final_models <- function(run_info,
   run_global_models <- prev_log_df$run_global_models
   run_local_models <- prev_log_df$run_local_models
   run_ensemble_models <- prev_log_df$run_ensemble_models
+  local_reads <- is.null(run_info$storage_object) &&
+    run_info$data_output %in% c("csv", "parquet", "rds")
 
   if (forecast_approach != "bottoms_up" & date_type == "week") {
     # turn off daily conversion before hts recon
@@ -149,13 +151,14 @@ final_models <- function(run_info,
     combo_diff <- combo_list
   } else {
     # Multi combo mode - get all combos and check which are complete
-    combo_list <- list_files(
+    forecast_files <- list_files(
       run_info$storage_object,
       paste0(
         run_info$path, "/forecasts/*", hash_data(run_info$project_name), "-",
         hash_data(run_info$run_name), "*_models.", run_info$data_output
       )
-    ) %>%
+    )
+    combo_list <- forecast_files %>%
       tibble::tibble(
         Path = .,
         File = fs::path_file(.)
@@ -165,13 +168,16 @@ final_models <- function(run_info,
       dplyr::pull(Combo) %>%
       unique()
 
-    prev_combo_list <- list_files(
+    previous_files <- if (local_reads) {
+      forecast_files[endsWith(forecast_files, paste0("-average_models.", run_info$data_output))]
+    } else list_files(
       run_info$storage_object,
       paste0(
         run_info$path, "/forecasts/*", hash_data(run_info$project_name), "-",
         hash_data(run_info$run_name), "*average_models.", run_info$data_output
       )
-    ) %>%
+    )
+    prev_combo_list <- previous_files %>%
       tibble::tibble(
         Path = .,
         File = fs::path_file(.)
@@ -186,7 +192,12 @@ final_models <- function(run_info,
   # check if previous run is complete
   recon_complete <- TRUE
   if (forecast_approach != "bottoms_up") {
-    recon_files <- list_files(
+    recon_files <- if (local_reads) {
+      local_artifact_files(
+        local_artifact_path(run_info, "forecasts", "-reconciled", hash_data("Best-Model")),
+        allow_missing = TRUE
+      )
+    } else list_files(
       run_info$storage_object,
       paste0(
         run_info$path, "/forecasts/*", hash_data(run_info$project_name), "-",

--- a/R/hierarchy.R
+++ b/R/hierarchy.R
@@ -547,10 +547,14 @@ reconcile_hierarchical_data <- function(run_info,
     )
   }
 
-  unreconciled_tbl <- read_file(run_info,
+  unreconciled_tbl <- if (condensed && is.null(run_info$storage_object) &&
+    identical(return_type, "df") && run_info$data_output %in% c("csv", "parquet", "rds")) {
+    read_local_artifacts(run_info, condensed_files)
+  } else read_file(run_info,
     path = fcst_path,
     return_type = return_type
-  ) %>%
+  )
+  unreconciled_tbl <- unreconciled_tbl %>%
     dplyr::mutate(Train_Test_ID = as.numeric(Train_Test_ID))
 
   # get models to reconcile down to lowest level

--- a/R/prep_models.R
+++ b/R/prep_models.R
@@ -74,6 +74,10 @@ prep_models <- function(run_info,
   seasonal_period <- validate_seasonal_period(seasonal_period)
   check_input_type("seed", seed, "numeric")
 
+  if (is.null(run_info$storage_object) && run_info$data_output %in% c("csv", "parquet", "rds")) {
+    run_info$recipe_inventory <- new.env(parent = emptyenv())
+  }
+
   # create model workflows
   model_workflows(
     run_info,
@@ -359,7 +363,10 @@ train_test_split <- function(run_info,
       run_info$data_output
     ) %>% fs::path_tidy()
   } else {
-    file_name <- list_files(
+    file_name <- if (is.null(run_info$storage_object) &&
+      run_info$data_output %in% c("csv", "parquet", "rds")) {
+      preparation_recipe_files(run_info)[1]
+    } else list_files(
       run_info$storage_object,
       paste0(
         run_info$path, "/prep_data/*", hash_data(run_info$project_name), "-",
@@ -634,13 +641,17 @@ model_workflows <- function(run_info,
       file_name_tbl <- rbind(file_name_tbl, temp_file_name_tbl)
     }
   } else {
-    file_name_tbl <- list_files(
+    recipe_files <- if (is.null(run_info$storage_object) &&
+      run_info$data_output %in% c("csv", "parquet", "rds")) {
+      preparation_recipe_files(run_info)
+    } else list_files(
       run_info$storage_object,
       paste0(
         run_info$path, "/prep_data/*", hash_data(run_info$project_name), "-",
         hash_data(run_info$run_name), "*R*.", run_info$data_output
       )
-    ) %>%
+    )
+    file_name_tbl <- recipe_files %>%
       tibble::tibble(
         Path = .,
         File = fs::path_file(.)
@@ -896,13 +907,17 @@ model_hyperparameters <- function(run_info,
       file_name_tbl <- rbind(file_name_tbl, temp_file_name_tbl)
     }
   } else {
-    file_name_tbl <- list_files(
+    recipe_files <- if (is.null(run_info$storage_object) &&
+      run_info$data_output %in% c("csv", "parquet", "rds")) {
+      preparation_recipe_files(run_info)
+    } else list_files(
       run_info$storage_object,
       paste0(
         run_info$path, "/prep_data/*", hash_data(run_info$project_name), "-",
         hash_data(run_info$run_name), "*R*.", run_info$data_output
       )
-    ) %>%
+    )
+    file_name_tbl <- recipe_files %>%
       tibble::tibble(
         Path = .,
         File = fs::path_file(.)

--- a/R/read_write_data.R
+++ b/R/read_write_data.R
@@ -48,9 +48,13 @@ get_forecast_data <- function(run_info,
   # check input values
   check_input_type("run_info", run_info, "list")
   check_input_type("return_type", return_type, "character", c("df", "sdf"))
+  local_reads <- is.null(run_info$storage_object) && identical(return_type, "df") &&
+    run_info$data_output %in% c("csv", "parquet", "rds")
 
   # get input values
-  log_df <- read_file(run_info,
+  log_df <- if (local_reads) {
+    read_local_artifacts(run_info, local_artifact_path(run_info, "logs", extension = "csv"))
+  } else read_file(run_info,
     file_list = paste0(
       run_info$path, "/logs/",
       hash_data(run_info$project_name), "-",
@@ -61,6 +65,8 @@ get_forecast_data <- function(run_info,
 
   combo_variables <- strsplit(log_df$combo_variables, split = "---")[[1]]
   forecast_approach <- log_df$forecast_approach
+  single_combo <- local_reads && length(run_info$combo) == 1L &&
+    identical(forecast_approach, "bottoms_up")
 
   # get train test split data
   model_train_test_tbl <- read_file(run_info,
@@ -79,7 +85,9 @@ get_forecast_data <- function(run_info,
     hash_data(run_info$run_name), "*condensed", ".", run_info$data_output
   )
 
-  condensed_files <- list_files(run_info$storage_object, fs::path(cond_path))
+  condensed_files <- if (local_reads) {
+    local_artifact_inventory(run_info, "forecasts", "*condensed")
+  } else list_files(run_info$storage_object, fs::path(cond_path))
 
   if (length(condensed_files) > 0) {
     condensed <- TRUE
@@ -105,10 +113,17 @@ get_forecast_data <- function(run_info,
     )
   }
 
-  forecast_tbl <- read_file(run_info,
+  forecast_tbl <- if (local_reads && condensed && identical(forecast_approach, "bottoms_up")) {
+    read_local_artifacts(run_info, condensed_files)
+  } else if (single_combo) {
+    read_file(run_info,
+      file_list = local_model_artifact_files(run_info, "forecasts"), strict = TRUE
+    )
+  } else read_file(run_info,
     path = fcst_path,
     return_type = return_type
-  ) %>%
+  )
+  forecast_tbl <- forecast_tbl %>%
     dplyr::mutate(Train_Test_ID = as.numeric(Train_Test_ID)) %>%
     dplyr::left_join(model_train_test_tbl,
       by = "Train_Test_ID"
@@ -179,6 +194,14 @@ get_trained_models <- function(run_info) {
   # check input values
   check_input_type("run_info", run_info, "list")
 
+  if (is.null(run_info$storage_object) && length(run_info$combo) == 1L &&
+    identical(run_info$object_output, "rds")) {
+    return(read_file(run_info,
+      file_list = local_model_artifact_files(run_info, "models", extension = run_info$object_output),
+      strict = TRUE
+    ))
+  }
+
   # get trained files
   model_path <- paste0(
     "/models/*", hash_data(run_info$project_name), "-", hash_data(run_info$run_name),
@@ -235,9 +258,13 @@ get_prepped_data <- function(run_info,
   check_input_type("run_info", run_info, "list")
   check_input_type("recipe", recipe, "character", c("R1", "R2"))
   check_input_type("return_type", return_type, "character", c("df", "sdf"))
+  local_reads <- is.null(run_info$storage_object) && identical(return_type, "df") &&
+    run_info$data_output %in% c("csv", "parquet", "rds")
 
   # get input values
-  log_df <- read_file(run_info,
+  log_df <- if (local_reads) {
+    read_local_artifacts(run_info, local_artifact_path(run_info, "logs", extension = "csv"))
+  } else read_file(run_info,
     file_list = paste0(
       run_info$path, "/logs/",
       hash_data(run_info$project_name), "-",
@@ -254,10 +281,15 @@ get_prepped_data <- function(run_info,
     hash_data(run_info$run_name), "*", recipe, ".", run_info$data_output
   )
 
-  prep_data_tbl <- read_file(run_info,
+  prep_data_tbl <- if (local_reads && length(run_info$combo) == 1L) {
+    read_local_artifacts(run_info,
+      local_artifact_path(run_info, "prep_data", paste0("-", recipe), run_info$combo)
+    )
+  } else read_file(run_info,
     path = data_path,
     return_type = return_type
-  ) %>%
+  )
+  prep_data_tbl <- prep_data_tbl %>%
     tidyr::separate(
       col = Combo,
       into = combo_variables,
@@ -311,7 +343,7 @@ get_prepped_models <- function(run_info) {
 
   # get prepped model info
   data_path <- paste0(
-    run_info$path,
+    if (is.null(run_info$storage_object) && is.null(run_info$path)) tempdir() else run_info$path,
     "/prep_models/", hash_data(run_info$project_name), "-",
     hash_data(run_info$run_name)
   )
@@ -611,6 +643,7 @@ download_file <- function(storage_object,
 #' @param schema column schema for arrow::open_dataset()
 #' @param allow_missing whether a missing optional artifact returns an empty
 #'   result instead of an error
+#' @param strict whether CSV fallback metadata and read failures are errors
 #'
 #' @return file read into memory
 #' @noRd
@@ -619,7 +652,8 @@ read_file <- function(run_info,
                       file_list = NULL,
                       return_type = "df",
                       schema = NULL,
-                      allow_missing = FALSE) {
+                      allow_missing = FALSE,
+                      strict = FALSE) {
   storage_object <- run_info$storage_object
 
   if (!is.null(path)) {
@@ -688,6 +722,11 @@ read_file <- function(run_info,
                 {
                   # Check if file is empty or has no data rows
                   file_info <- file.info(path)
+                  if (isTRUE(strict) && is.na(file_info$size)) {
+                    stop("Cannot read Finn CSV artifact: ", path, ". ", conditionMessage(e),
+                      call. = FALSE
+                    )
+                  }
                   if (is.na(file_info$size) || file_info$size == 0) {
                     return(tibble::tibble())
                   }
@@ -699,6 +738,7 @@ read_file <- function(run_info,
                   df
                 },
                 error = function(inner_e) {
+                  if (isTRUE(strict)) stop(inner_e)
                   warning(paste0("Skipping empty or unreadable file: ", path))
                   return(tibble::tibble())
                 }
@@ -746,15 +786,93 @@ read_file <- function(run_info,
   }
 }
 
+local_artifact_inventory <- function(run_info, folder, suffix = "*",
+                                      extension = run_info$data_output) {
+  pattern <- local_artifact_path(run_info, folder, suffix, extension = extension)
+  list_files(NULL, fs::path(fs::path_dir(pattern), paste0("*", fs::path_file(pattern))))
+}
+
+preparation_recipe_files <- function(run_info) {
+  inventory <- run_info$recipe_inventory
+  if (!is.null(inventory) && exists("files", envir = inventory, inherits = FALSE)) {
+    return(inventory$files)
+  }
+  files <- local_artifact_inventory(run_info, "prep_data", "-*R*")
+  if (!is.null(inventory)) inventory$files <- files
+  files
+}
+
+local_model_artifact_files <- function(run_info, folder,
+                                        extension = run_info$data_output) {
+  local_artifact_files(local_artifact_path(run_info, folder,
+    suffix = paste0("-", c("average_models", "ensemble_models", "global_models", "single_models")),
+    combo = run_info$combo, extension = extension
+  ), allow_missing = TRUE)
+}
+
+local_artifact_path <- function(run_info, folder, suffix = "", combo = NULL,
+                                 extension = run_info$data_output) {
+  if (!is.null(combo) && length(combo) == 0L) return(character())
+  root <- if (is.null(run_info$path)) tempdir() else run_info$path
+  combo_suffix <- if (is.null(combo)) "" else paste0("-", combo)
+  fs::path(root, folder, paste0(
+    hash_data(run_info$project_name), "-", hash_data(run_info$run_name),
+    combo_suffix, suffix, ".", extension
+  ))
+}
+
+local_artifact_files <- function(files, allow_missing = FALSE) {
+  files <- as.character(files)
+  info <- fs::file_info(files, fail = TRUE, follow = TRUE)
+  present <- !is.na(info$type)
+  invalid <- present & info$type != "file"
+  if (any(invalid)) {
+    stop("Finn artifact is not a regular file: ", paste(files[invalid], collapse = ", "),
+      call. = FALSE
+    )
+  }
+  if (!allow_missing && any(!present)) {
+    stop("Missing required Finn artifact: ", paste(files[!present], collapse = ", "),
+      call. = FALSE
+    )
+  }
+  files <- files[present]
+  unreadable <- file.access(files, mode = 4) != 0
+  if (any(unreadable)) {
+    stop("Cannot read Finn artifact: ", paste(files[unreadable], collapse = ", "),
+      call. = FALSE
+    )
+  }
+  files
+}
+
+read_local_artifacts <- function(run_info, file_list, return_type = "df",
+                                  allow_missing = FALSE) {
+  files <- local_artifact_files(file_list, allow_missing = allow_missing)
+  read_file(run_info, file_list = files, return_type = return_type,
+    allow_missing = allow_missing, strict = TRUE
+  )
+}
+
 #' Load recipe data into memory
 #'
 #' @param run_info run info using the [set_run_info()] function
 #' @param combo how much recipe data to ready into memory
+#' @param recipes resolved recipes when already available to the caller
+#' @param file_list previously discovered recipe paths
 #'
 #' @return recipe data as data frame
 #' @noRd
 get_recipe_data <- function(run_info,
-                            combo = "single") {
+                            combo = "single",
+                            recipes = NULL,
+                            file_list = NULL) {
+  local_reads <- is.null(run_info$storage_object) &&
+    run_info$data_output %in% c("csv", "parquet", "rds")
+  if (local_reads && identical(combo, "single") && length(run_info$combo) == 1L) {
+    combo <- run_info$combo
+  }
+
   get_combo <- function(df,
                         combo) {
     if (combo == "single") {
@@ -770,24 +888,65 @@ get_recipe_data <- function(run_info,
 
   recipe_tbl <- tibble::tibble()
 
-  file_name_tbl <- list_files(
-    run_info$storage_object,
-    paste0(
-      run_info$path, "/prep_data/*", hash_data(run_info$project_name), "-",
-      hash_data(run_info$run_name), "*R*.", run_info$data_output
+  if (local_reads && !combo %in% c("single", "All-Data")) {
+    if (is.null(recipes)) {
+      log_df <- read_local_artifacts(run_info,
+        local_artifact_path(run_info, "logs", extension = "csv")
+      )
+      configured <- log_df$recipes_to_run
+      configured <- if (length(configured) == 0L || is.na(configured[[1]])) {
+        NULL
+      } else {
+        strsplit(configured[[1]], "---", fixed = TRUE)[[1]]
+      }
+      recipes <- get_recipes_to_run(configured, log_df$date_type)
+    }
+    recipes <- sort(unique(recipes))
+    file_name_tbl <- tibble::tibble(
+      Path = local_artifact_path(run_info, "prep_data", paste0("-", recipes), combo),
+      Recipe = recipes
     )
-  ) %>%
-    tibble::tibble(
-      Path = .,
-      File = fs::path_file(.)
-    ) %>%
-    tidyr::separate(File, into = c("Project", "Run", "Combo", "Recipe"), sep = "-", remove = TRUE) %>%
-    get_combo(combo) %>%
-    dplyr::mutate(Recipe = substr(Recipe, 1, 2))
+  } else {
+    if (is.null(file_list) || !local_reads) {
+      file_list <- list_files(
+        run_info$storage_object,
+        if (local_reads) {
+          fs::path(
+            if (is.null(run_info$path)) tempdir() else run_info$path,
+            "prep_data", paste0(
+              "*", hash_data(run_info$project_name), "-", hash_data(run_info$run_name),
+              "-*R*.", run_info$data_output
+            )
+          )
+        } else {
+          paste0(
+            run_info$path, "/prep_data/*", hash_data(run_info$project_name), "-",
+            hash_data(run_info$run_name), "*R*.", run_info$data_output
+          )
+        }
+      )
+    }
+    file_name_tbl <- tibble::tibble(Path = file_list, File = fs::path_file(file_list)) %>%
+      tidyr::separate(File, into = c("Project", "Run", "Combo", "Recipe"), sep = "-", remove = TRUE) %>%
+      get_combo(combo) %>%
+      dplyr::mutate(Recipe = substr(Recipe, 1, 2))
+  }
+
+  if (local_reads && !is.null(recipes)) {
+    file_name_tbl <- dplyr::filter(file_name_tbl, Recipe %in% recipes)
+  }
 
   for (recipe in unique(file_name_tbl$Recipe)) {
     temp_path <- file_name_tbl %>%
       dplyr::filter(Recipe == recipe)
+
+    if (local_reads) {
+      temp_file_tbl <- read_local_artifacts(run_info, temp_path$Path)
+      recipe_tbl <- dplyr::bind_rows(recipe_tbl,
+        tibble::tibble(Recipe = recipe, Data = list(temp_file_tbl))
+      )
+      next
+    }
 
     if (nrow(temp_path) > 1) {
       temp_path <- paste0(

--- a/R/run_info.R
+++ b/R/run_info.R
@@ -311,6 +311,14 @@ get_run_info <- function(project_name = NULL,
     path = path
   )
 
+  if (is.null(storage_object) && !is.null(project_name) && !is.null(run_name)) {
+    info_list$project_name <- project_name
+    info_list$run_name <- run_name
+    return(read_local_artifacts(info_list,
+      local_artifact_path(info_list, "logs", extension = "csv")
+    ))
+  }
+
   # read run metadata
   if (!is.null(project_name) & !is.null(run_name) & !is.null(path)) {
     # read specific file path

--- a/R/train_models.R
+++ b/R/train_models.R
@@ -189,6 +189,7 @@ train_models <- function(run_info,
 
   # get list of tasks to run
   current_combo_list <- c()
+  recipe_file_list <- NULL
 
   if ("combo" %in% names(run_info)) {
     # Single combo mode - determine which combo to run
@@ -205,13 +206,14 @@ train_models <- function(run_info,
     }
   } else {
     # Multi combo mode - get all combos from prep_data
-    all_combo_list <- list_files(
+    recipe_file_list <- list_files(
       run_info$storage_object,
       paste0(
         run_info$path, "/prep_data/*", hash_data(run_info$project_name), "-",
         hash_data(run_info$run_name), "*R*.", run_info$data_output
       )
-    ) %>%
+    )
+    all_combo_list <- recipe_file_list %>%
       tibble::tibble(
         Path = .,
         File = fs::path_file(.)
@@ -350,7 +352,13 @@ train_models <- function(run_info,
       combo_hash <- x
 
       model_recipe_tbl <- get_recipe_data(run_info,
-        combo = x
+        combo = x,
+        recipes = if (identical(x, "All-Data")) {
+          intersect(model_workflow_tbl$Model_Recipe, global_model_recipes)
+        } else {
+          unique(model_workflow_tbl$Model_Recipe)
+        },
+        file_list = recipe_file_list
       )
 
       if (combo_hash == "All-Data") {

--- a/tests/testthat/helper-artifact-io.R
+++ b/tests/testthat/helper-artifact-io.R
@@ -1,0 +1,288 @@
+artifact_test_run <- function(path, data_output = "csv", object_output = "rds") {
+  list(
+    project_name = paste0("artifact_io_", basename(tempfile())),
+    run_name = "artifact_run",
+    storage_object = NULL,
+    path = path,
+    data_output = data_output,
+    object_output = object_output
+  )
+}
+
+artifact_test_path <- function(run_info, folder, combo = NULL, suffix = "",
+                               extension = run_info$data_output) {
+  root <- if (is.null(run_info$path)) tempdir() else run_info$path
+  combo_suffix <- if (is.null(combo)) "" else paste0("-", hash_data(combo))
+  fs::path(root, folder, paste0(
+    hash_data(run_info$project_name), "-", hash_data(run_info$run_name),
+    combo_suffix, suffix, ".", extension
+  ))
+}
+
+artifact_test_log <- function(run_info, recipes = "R1", date_type = "month", ...) {
+  log <- tibble::tibble(
+    recipes_to_run = if (is.null(recipes)) NA_character_ else paste(recipes, collapse = "---"),
+    date_type = date_type,
+    ...
+  )
+  writer_info <- run_info
+  if (is.null(writer_info$path)) writer_info$path <- tempdir()
+  write_data(log, NULL, writer_info, "log", "logs")
+  log
+}
+
+local_artifact_spies <- function(max_listings = 0L, .env = parent.frame()) {
+  tracker <- new.env(parent = emptyenv())
+  tracker$listings <- 0L
+  tracker$directory_listings <- 0L
+  tracker$directory_calls <- list()
+  tracker$metadata_paths <- character()
+  tracker$access_paths <- character()
+  tracker$payload_paths <- character()
+  tracker$reads <- list()
+  original_list <- list_files
+  original_read <- read_file
+  original_info <- fs::file_info
+  original_access <- file.access
+  original_dir_ls <- fs::dir_ls
+  original_list_files <- list.files
+  original_dir <- dir
+  original_list_dirs <- list.dirs
+  original_rds <- readRDS
+  original_csv <- utils::read.csv
+  original_vroom <- vroom::vroom
+  directory_depth <- 0L
+  artifact_paths <- function(paths) {
+    paths <- gsub("\\", "/", as.character(paths), fixed = TRUE)
+    paths[grepl("(^|/)(prep_data|prep_models|models|logs|forecasts|input_data|eda|final_output)(/|$)", paths)]
+  }
+  record_directory <- function(path, api, read) {
+    paths <- artifact_paths(path)
+    if (directory_depth == 0L && length(paths) > 0L) {
+      tracker$directory_listings <- tracker$directory_listings + 1L
+      tracker$directory_calls[[length(tracker$directory_calls) + 1L]] <- list(api = api, paths = paths)
+      if (tracker$directory_listings > max_listings) {
+        stop("Unexpected low-level directory enumeration in artifact read", call. = FALSE)
+      }
+    }
+    directory_depth <<- directory_depth + 1L
+    on.exit(directory_depth <<- directory_depth - 1L)
+    force(read)
+  }
+  testthat::local_mocked_bindings(
+    list_files = function(storage_object, path, ...) {
+      if (grepl("*", path, fixed = TRUE)) {
+        tracker$listings <- tracker$listings + 1L
+        if (tracker$listings > max_listings) {
+          stop("Unexpected directory enumeration in artifact read", call. = FALSE)
+        }
+      }
+      original_list(storage_object, path, ...)
+    },
+    read_file = function(run_info, path = NULL, file_list = NULL, ...) {
+      tracker$reads[[length(tracker$reads) + 1L]] <- list(
+        path = path, file_list = file_list
+      )
+      original_read(run_info, path = path, file_list = file_list, ...)
+    },
+    download_file = function(...) {
+      stop("Unexpected download in local artifact read", call. = FALSE)
+    },
+    .package = "finnts",
+    .env = .env
+  )
+  testthat::local_mocked_bindings(
+    file_info = function(path, ...) {
+      tracker$metadata_paths <- c(tracker$metadata_paths, artifact_paths(path))
+      original_info(path, ...)
+    },
+    dir_ls = function(path = ".", ...) record_directory(path, "fs::dir_ls", original_dir_ls(path, ...)),
+    .package = "fs", .env = .env
+  )
+  testthat::local_mocked_bindings(
+    file.access = function(names, mode = 0) {
+      tracker$access_paths <- c(tracker$access_paths, artifact_paths(names))
+      original_access(names, mode)
+    },
+    readRDS = function(file, ...) {
+      if (is.character(file)) tracker$payload_paths <- c(tracker$payload_paths, artifact_paths(file))
+      original_rds(file, ...)
+    },
+    list.files = function(path = ".", ...) record_directory(path, "base::list.files", original_list_files(path, ...)),
+    dir = function(path = ".", ...) record_directory(path, "base::dir", original_dir(path, ...)),
+    list.dirs = function(path = ".", ...) record_directory(path, "base::list.dirs", original_list_dirs(path, ...)),
+    .package = "base", .env = .env
+  )
+  testthat::local_mocked_bindings(
+    read.csv = function(file, ...) {
+      if (is.character(file)) tracker$payload_paths <- c(tracker$payload_paths, artifact_paths(file))
+      original_csv(file, ...)
+    },
+    .package = "utils", .env = .env
+  )
+  testthat::local_mocked_bindings(
+    vroom = function(file, ...) {
+      if (is.character(file)) tracker$payload_paths <- c(tracker$payload_paths, artifact_paths(file))
+      original_vroom(file, ...)
+    },
+    .package = "vroom", .env = .env
+  )
+  if (requireNamespace("arrow", quietly = TRUE)) {
+    original_parquet <- arrow::read_parquet
+    testthat::local_mocked_bindings(
+      read_parquet = function(file, ...) {
+        if (is.character(file)) tracker$payload_paths <- c(tracker$payload_paths, artifact_paths(file))
+        original_parquet(file, ...)
+      },
+      .package = "arrow", .env = .env
+    )
+  }
+  tracker
+}
+
+artifact_test_recipe <- function(run_info, combo, recipe, value = 1) {
+  data <- tibble::tibble(
+    Combo = combo,
+    Date = as.Date("2024-01-01") + 0:2,
+    Target = value + 0:2
+  )
+  writer_info <- run_info
+  if (is.null(writer_info$path)) writer_info$path <- tempdir()
+  write_data(data, combo, writer_info, "data", "prep_data", paste0("-", recipe))
+  data
+}
+
+artifact_test_agent <- function(path, data_output = "csv") {
+  project_info <- artifact_test_run(path, data_output)
+  project_info$combo_variables <- "ID"
+  project_info$target_variable <- "Target"
+  project_info$date_type <- "month"
+  list(
+    project_info = project_info,
+    run_id = project_info$run_name,
+    hist_start_date = as.Date("2020-01-01"),
+    hist_end_date = as.Date("2024-01-01"),
+    external_regressors = NULL,
+    forecast_horizon = 2,
+    back_test_scenarios = 1,
+    back_test_spacing = 1
+  )
+}
+
+artifact_test_eda <- function(agent_info, combos = c("A", "B"), omit = character()) {
+  run_info <- agent_info$project_info
+  row_counts <- 4 + 2 * seq_along(combos)
+  write_data(list(
+    total_rows = sum(row_counts), n_series = length(combos), rows_min = min(row_counts), rows_max = max(row_counts),
+    rows_avg = mean(row_counts), neg_count = 0, neg_pct = 0,
+    date_start = "2020-01-01", date_end = "2024-01-01"
+  ), NULL, run_info, "object", "eda", "-data_profile")
+  write_data(list(hierarchy = "none"), NULL, run_info, "object", "eda", "-hierarchy")
+  for (combo in combos) {
+    offset <- match(combo, combos) - 1L
+    row_count <- row_counts[[offset + 1L]]
+    values <- c(acf = 0.5 - 0.8 * offset, pacf = 0.4 + 0.4 * offset, add_season = 0.2 + 0.4 * offset)
+    for (suffix in setdiff(c("acf", "pacf", "add_season"), omit)) {
+      write_data(tibble::tibble(Combo = combo, Lag = 1, Value = unname(values[[suffix]])),
+        combo, run_info, "data", "eda", paste0("-", suffix)
+      )
+    }
+    scans <- list(
+      stationarity = tibble::tibble(Combo = combo, stationary_adf = offset == 0L, stationary_kpss = TRUE),
+      missing = tibble::tibble(Combo = combo, total_rows = row_count, missing_count = 2 * offset,
+        missing_pct = 100 * 2 * offset / row_count, longest_gap = 2 * offset),
+      outliers = tibble::tibble(Combo = combo, total_rows = row_count, outlier_count = 2 * offset,
+        outlier_pct = 100 * 2 * offset / row_count,
+        first_outlier_dt = if (offset == 0L) as.Date(NA) else as.Date("2020-03-01"),
+        last_outlier_dt = if (offset == 0L) as.Date(NA) else as.Date("2020-06-01")),
+      xreg_scan = tibble::tibble(Combo = combo, Regressor = "price", Lag = 1, dCor = 0.25 + 0.5 * offset)
+    )
+    for (suffix in setdiff(names(scans), omit)) {
+      write_data(scans[[suffix]], combo, run_info, "data", "eda", paste0("-", suffix))
+    }
+    write_data(tibble::tibble(Combo = combo, Date = as.Date("2024-01-01"), Target = 1),
+      combo, run_info, "data", "input_data"
+    )
+  }
+  invisible(agent_info)
+}
+
+artifact_expected_eda <- function() {
+  profile <- tibble::tibble(
+    Combo = "All", Analysis_Type = "Data_Profile",
+    Metric = c("Total_Rows", "Number_Series", "Min_Rows_Per_Series", "Max_Rows_Per_Series",
+      "Avg_Rows_Per_Series", "Negative_Count", "Negative_Percent", "Start_Date", "End_Date"),
+    Value = c("14", "2", "6", "8", "7", "0", "0", "2020-01-01", "2024-01-01")
+  )
+  series <- tibble::tibble(
+    Combo = rep(c("A", "B"), each = 14),
+    Analysis_Type = rep(c("ACF", "PACF", "Stationarity", rep("Missing_Data", 4),
+      rep("Outliers", 5), "Additional_Seasonality", "External_Regressor_Distance_Correlation"), 2),
+    Metric = rep(c("Lag_1", "Lag_1", "is_stationary", "total_rows", "missing_count", "missing_pct",
+      "longest_gap", "total_rows", "outlier_count", "outlier_pct", "first_outlier_dt", "last_outlier_dt",
+      "Lag_1", "price_Lag_1"), 2),
+    Value = c("0.5", "0.4", "TRUE", "6", "0", "0", "0", "6", "0", "0", NA, NA, "0.2", "0.25",
+      "-0.3", "0.8", "FALSE", "8", "2", "25", "2", "8", "2", "25", "2020-03-01", "2020-06-01", "0.6", "0.75")
+  )
+  hierarchy <- tibble::tibble(Combo = "All", Analysis_Type = "Hierarchy", Metric = "hierarchy_type", Value = "none")
+  dplyr::bind_rows(profile, series, hierarchy) %>% dplyr::arrange(Combo, Analysis_Type, Metric)
+}
+
+artifact_test_forecast <- function(run_info, combo = "A", suffix = "single_models",
+                                   model = "meanf", best = "Yes", write_output = TRUE) {
+  data <- tibble::tibble(
+    Combo = combo, Combo_ID = combo, Hyperparameter_ID = 1,
+    Model_ID = paste0(model, "--local--R1"), Model_Name = model,
+    Model_Type = "local", Recipe_ID = "R1", Train_Test_ID = 1,
+    Date = as.Date("2024-02-01"), Forecast = 100, Target = NA_real_,
+    Best_Model = best
+  )
+  if (write_output) {
+    write_data(data, combo, run_info, "data", "forecasts", paste0("-", suffix))
+  }
+  data
+}
+
+artifact_test_splits <- function(run_info) {
+  splits <- tibble::tibble(Run_Type = "Future_Forecast", Train_Test_ID = 1)
+  write_data(splits, NULL, run_info, "data", "prep_models", "-train_test_split")
+  splits
+}
+
+artifact_test_model_log <- function(run_info, forecast_approach = "bottoms_up") {
+  artifact_test_log(run_info, combo_variables = "ID", forecast_approach = forecast_approach,
+    num_hyperparameters = 1, negative_forecast = FALSE, run_global_models = FALSE,
+    run_local_models = TRUE, run_ensemble_models = TRUE,
+    models_to_run = NA_character_, models_not_to_run = NA_character_
+  )
+}
+
+artifact_test_selected_models <- function(agent_info) {
+  best_runs <- tibble::tibble(combo = c("A", "B"), best_run_name = c("selected_A", "selected_B"),
+    model_type = "local"
+  )
+  for (index in seq_len(nrow(best_runs))) {
+    selected <- agent_info$project_info
+    combo <- best_runs$combo[[index]]
+    selected$project_name <- paste0(selected$project_name, "_", hash_data(combo))
+    selected$run_name <- best_runs$best_run_name[[index]]
+    write_data(tibble::tibble(
+      Model_ID = "meanf--local--R1", Model_Name = "meanf", Model_Type = "local",
+      Model_Fit = list(list(value = 100))
+    ), combo, selected, "object", "models", "-single_models")
+    artifact_test_forecast(selected, combo)
+  }
+  best_runs
+}
+
+local_artifact_summary_mocks <- function(best_runs, .env = parent.frame()) {
+  testthat::local_mocked_bindings(
+    check_agent_info = function(...) invisible(NULL),
+    vip_available = function(...) TRUE,
+    get_best_agent_run = function(...) best_runs,
+    summarize_model_meanf = function(...) tibble::tibble(section = "model", name = "mean", value = "100"),
+    par_start = function(...) list(cl = NULL, packages = character(), foreach_operator = foreach::`%do%`),
+    par_end = function(...) invisible(NULL),
+    .package = "finnts", .env = .env
+  )
+}

--- a/tests/testthat/test-agent-artifact-reads.R
+++ b/tests/testthat/test-agent-artifact-reads.R
@@ -1,0 +1,248 @@
+test_that("local EDA reads exact artifacts with independently expected metrics", {
+  agent_info <- artifact_test_agent(withr::local_tempdir())
+  agent_info$external_regressors <- "price"
+  artifact_test_eda(agent_info)
+  tracker <- local_artifact_spies()
+  tables <- list()
+  original_table <- make_pipe_table
+  testthat::local_mocked_bindings(
+    make_pipe_table = function(data) {
+      tables[[length(tables) + 1L]] <<- data
+      original_table(data)
+    },
+    .package = "finnts"
+  )
+
+  result <- load_eda_results(agent_info, hash_data("A"))
+
+  expect_equal(tables, list(
+    tibble::tibble(Lag = 1, Value = 0.5),
+    tibble::tibble(Lag = 1, Value = 0.4),
+    tibble::tibble(stationary_adf = TRUE, stationary_kpss = TRUE),
+    tibble::tibble(Lag = 1, Value = 0.2),
+    tibble::tibble(Regressor = "price", Lag = 1, dCor = 0.25)
+  ))
+  expect_match(result, "price")
+  expect_match(result, "None observed")
+  expect_match(result, "Missing Count: 0", fixed = TRUE)
+  expect_match(result, "Outlier Count: 0", fixed = TRUE)
+  expect_equal(tracker$listings, 0L)
+  expect_equal(tracker$directory_listings, 0L)
+  expect_length(tracker$reads, 9L)
+})
+
+test_that("local EDA for a different combo cannot reuse the first series metrics", {
+  agent_info <- artifact_test_agent(withr::local_tempdir())
+  agent_info$external_regressors <- "price"
+  artifact_test_eda(agent_info)
+  tracker <- local_artifact_spies()
+  tables <- list()
+  original_table <- make_pipe_table
+  testthat::local_mocked_bindings(
+    make_pipe_table = function(data) {
+      tables[[length(tables) + 1L]] <<- data
+      original_table(data)
+    },
+    .package = "finnts"
+  )
+
+  result <- load_eda_results(agent_info, hash_data("B"))
+
+  expect_equal(tables, list(
+    tibble::tibble(Lag = 1, Value = -0.3),
+    tibble::tibble(Lag = 1, Value = 0.8),
+    tibble::tibble(stationary_adf = FALSE, stationary_kpss = TRUE),
+    tibble::tibble(Lag = 1, Value = 0.6),
+    tibble::tibble(Regressor = "price", Lag = 1, dCor = 0.75)
+  ))
+  expect_match(result, "Missing Count: 2", fixed = TRUE)
+  expect_match(result, "Missing Percent: 25%", fixed = TRUE)
+  expect_match(result, "Outlier Count: 2", fixed = TRUE)
+  expect_match(result, "First Outlier Date: 2020-03-01", fixed = TRUE)
+  expect_match(result, "Last Outlier Date: 2020-06-01", fixed = TRUE)
+  expect_equal(tracker$directory_listings, 0L)
+})
+
+test_that("local EDA does not require regressor artifacts when regressors are disabled", {
+  agent_info <- artifact_test_agent(withr::local_tempdir())
+  artifact_test_eda(agent_info, omit = "xreg_scan")
+  tracker <- local_artifact_spies()
+
+  result <- load_eda_results(agent_info, hash_data("A"))
+
+  expect_match(result, "No external regressors")
+  expect_equal(tracker$listings, 0L)
+  expect_length(tracker$reads, 8L)
+})
+
+test_that("missing required local EDA is not mistaken for another combo", {
+  agent_info <- artifact_test_agent(withr::local_tempdir())
+  artifact_test_eda(agent_info, combos = "B")
+  tracker <- local_artifact_spies()
+
+  expect_error(load_eda_results(agent_info, hash_data("A")),
+    "Missing required Finn artifact.*acf"
+  )
+  expect_equal(tracker$listings, 0L)
+})
+
+test_that("singleton EDA caches do not enumerate input or EDA folders", {
+  agent_info <- artifact_test_agent(withr::local_tempdir())
+  agent_info$project_info$combo_variables <- c("Country", "Product")
+  artifact_test_eda(agent_info)
+  tracker <- local_artifact_spies()
+
+  expect_match(data_profile(agent_info), "already exists")
+  expect_match(hierarchy_detect(agent_info), "already exists")
+  expect_equal(tracker$listings, 0L)
+})
+
+test_that("combo resolution reads only requested inputs and retains missing fallback", {
+  agent_info <- artifact_test_agent(withr::local_tempdir())
+  artifact_test_eda(agent_info)
+  missing_hash <- hash_data("missing")
+  tracker <- local_artifact_spies()
+
+  result <- resolve_combo_hashes(agent_info, c(hash_data("A"), missing_hash))
+
+  expect_identical(result, c("A", missing_hash))
+  expect_equal(tracker$listings, 0L)
+  expect_length(tracker$reads, 1L)
+})
+
+test_that("local submission reads its exact input before starting modeling", {
+  agent_info <- artifact_test_agent(withr::local_tempdir())
+  artifact_test_eda(agent_info)
+  tracker <- local_artifact_spies()
+  testthat::local_mocked_bindings(
+    set_run_info = function(...) stop("submission input verified", call. = FALSE),
+    .package = "finnts"
+  )
+
+  expect_error(submit_fcst_run(agent_info, list(), hash_data("A"), "test"),
+    "submission input verified"
+  )
+  expect_equal(tracker$listings, 0L)
+  expect_length(tracker$reads, 1L)
+  expect_equal(tracker$reads[[1]]$file_list,
+    as.character(artifact_test_path(agent_info$project_info, "input_data", "A"))
+  )
+})
+
+test_that("reconciliation reads the selected run split by exact path", {
+  agent_info <- artifact_test_agent(withr::local_tempdir())
+  project_info <- agent_info$project_info
+  selected <- project_info
+  selected$project_name <- paste0(project_info$project_name, "_", hash_data("A"))
+  selected$run_name <- "selected"
+  write_data(tibble::tibble(Run_Type = "Future_Forecast", Train_Test_ID = 1),
+    NULL, selected, "data", "prep_models", "-train_test_split"
+  )
+  tracker <- local_artifact_spies()
+  testthat::local_mocked_bindings(
+    check_agent_info = function(...) invisible(NULL),
+    get_best_agent_run = function(...) tibble::tibble(
+      negative_forecast = FALSE, model_type = "local", combo = "A", best_run_name = "selected"
+    ),
+    load_agent_forecast = function(...) stop("reconciliation split verified", call. = FALSE),
+    .package = "finnts"
+  )
+
+  expect_error(reconcile_agent_forecast(agent_info, project_info),
+    "reconciliation split verified"
+  )
+  expect_equal(tracker$listings, 0L)
+  expect_equal(tracker$reads[[1]]$file_list,
+    as.character(artifact_test_path(selected, "prep_models", suffix = "-train_test_split"))
+  )
+})
+
+test_that("model summaries consolidate only expected combo artifacts", {
+  agent_info <- artifact_test_agent(withr::local_tempdir())
+  best_runs <- artifact_test_selected_models(agent_info)
+  local_artifact_summary_mocks(best_runs)
+  write_data(tibble::tibble(Combo = "unrelated", Best_Model = "Yes"), "unrelated",
+    agent_info$project_info, "data", "models", "-model_summary"
+  )
+  tracker <- local_artifact_spies()
+
+  summarize_models(agent_info)
+  result <- get_summarized_models(agent_info)
+
+  expect_setequal(result$Combo, c("A", "B"))
+  expect_true(all(result$Best_Model == "Yes"))
+  expect_equal(tracker$listings, 0L)
+})
+
+test_that("model summary consolidation fails on a missing expected write", {
+  agent_info <- artifact_test_agent(withr::local_tempdir())
+  best_runs <- artifact_test_selected_models(agent_info)
+  local_artifact_summary_mocks(best_runs)
+  original_write <- write_data
+  testthat::local_mocked_bindings(
+    write_data = function(x, combo, run_info, output_type, folder = NULL, suffix = NULL) {
+      if (identical(combo, "B") && identical(suffix, "-model_summary")) return(invisible(NULL))
+      original_write(x, combo, run_info, output_type, folder, suffix)
+    },
+    .package = "finnts"
+  )
+  tracker <- local_artifact_spies()
+
+  expect_error(summarize_models(agent_info), "Missing required Finn artifact.*model_summary")
+  expect_equal(tracker$listings, 0L)
+})
+
+test_that("required local EDA propagates CSV failures after validation", {
+  agent_info <- artifact_test_agent(withr::local_tempdir())
+  artifact_test_eda(agent_info)
+  original_vroom <- vroom::vroom
+  original_info <- file.info
+  testthat::local_mocked_bindings(
+    vroom = function(file, ...) {
+      if (any(endsWith(as.character(file), "-acf.csv"))) {
+        stop("injected EDA read failure", call. = FALSE)
+      }
+      original_vroom(file, ...)
+    },
+    .package = "vroom"
+  )
+  testthat::local_mocked_bindings(
+    file.info = function(path, ...) {
+      if (any(endsWith(as.character(path), "-acf.csv"))) return(data.frame(size = NA_real_))
+      original_info(path, ...)
+    },
+    .package = "base"
+  )
+
+  expect_error(load_eda_results(agent_info, hash_data("A")),
+    "Cannot read Finn CSV artifact.*injected EDA read failure"
+  )
+})
+
+test_that("reconciliation cannot proceed after an unreadable selected CSV split", {
+  agent_info <- artifact_test_agent(withr::local_tempdir())
+  selected <- agent_info$project_info
+  selected$project_name <- paste0(selected$project_name, "_", hash_data("A"))
+  selected$run_name <- "selected"
+  artifact_test_splits(selected)
+  testthat::local_mocked_bindings(
+    check_agent_info = function(...) invisible(NULL),
+    get_best_agent_run = function(...) tibble::tibble(
+      negative_forecast = FALSE, model_type = "local", combo = "A", best_run_name = "selected"
+    ),
+    load_agent_forecast = function(...) stop("unreadable split was accepted", call. = FALSE),
+    .package = "finnts"
+  )
+  testthat::local_mocked_bindings(
+    vroom = function(...) stop("injected split read failure", call. = FALSE),
+    .package = "vroom"
+  )
+  testthat::local_mocked_bindings(
+    file.info = function(...) data.frame(size = NA_real_),
+    .package = "base"
+  )
+
+  expect_error(reconcile_agent_forecast(agent_info, agent_info$project_info),
+    "Cannot read Finn CSV artifact.*injected split read failure"
+  )
+})

--- a/tests/testthat/test-artifact-discovery-reuse.R
+++ b/tests/testthat/test-artifact-discovery-reuse.R
@@ -1,0 +1,156 @@
+test_that("global EDA reasoning uses one artifact inventory", {
+  agent_info <- artifact_test_agent(withr::local_tempdir())
+  agent_info$external_regressors <- "price"
+  artifact_test_eda(agent_info)
+  tracker <- local_artifact_spies(max_listings = 1L)
+  tables <- list()
+  original_table <- make_pipe_table
+  testthat::local_mocked_bindings(
+    make_pipe_table = function(data) {
+      tables[[length(tables) + 1L]] <<- data
+      original_table(data)
+    },
+    .package = "finnts"
+  )
+
+  result <- load_eda_results(agent_info)
+
+  expect_equal(tables, list(
+    tibble::tibble(Lag = 1, Combo_Count = 2L, Combo_Percent = 100, Avg_Value = 0.1, Mean_Abs_Value = 0.4),
+    tibble::tibble(Lag = 1, Combo_Count = 2L, Combo_Percent = 100, Avg_Value = 0.6, Mean_Abs_Value = 0.6),
+    tibble::tibble(Stationary = c("Non-Stationary", "Stationary"), Count = c(1L, 1L), Percent = c(50, 50)),
+    tibble::tibble(Lag = 1, Combo_Count = 2L, Combo_Percent = 100, Avg_ACF_Value = 0.4, Mean_Abs_ACF_Value = 0.4),
+    tibble::tibble(Regressor = "price", Lag = 1, Avg_dCor = 0.5, Median_dCor = 0.5, Max_dCor = 0.75)
+  ))
+  expect_match(result, "Total Rows: 14", fixed = TRUE)
+  expect_match(result, "Missing Count: 2", fixed = TRUE)
+  expect_match(result, "Missing Percent: 12%", fixed = TRUE)
+  expect_match(result, "Longest Gap: 2", fixed = TRUE)
+  expect_match(result, "Outlier Count: 2", fixed = TRUE)
+  expect_match(result, "Outlier Percent: 14%", fixed = TRUE)
+  expect_equal(tracker$listings, 1L)
+  expect_equal(tracker$directory_listings, 1L)
+})
+
+test_that("EDA consolidation reuses one discovery for every analysis type", {
+  agent_info <- artifact_test_agent(withr::local_tempdir())
+  agent_info$external_regressors <- "price"
+  artifact_test_eda(agent_info)
+  testthat::local_mocked_bindings(check_agent_info = function(...) invisible(NULL), .package = "finnts")
+  expected <- artifact_expected_eda()
+  tracker <- local_artifact_spies(max_listings = 1L)
+
+  save_eda_data(agent_info)
+  result <- get_eda_data(agent_info) %>% dplyr::arrange(Combo, Analysis_Type, Metric)
+
+  expect_equal(result, expected)
+  expect_equal(nrow(result), 38L)
+  expect_equal(anyDuplicated(result[c("Combo", "Analysis_Type", "Metric")]), 0L)
+  expect_equal(tracker$listings, 1L)
+  expect_equal(tracker$directory_listings, 1L)
+})
+
+test_that("independent EDA expectations reject a dropped-series mutation", {
+  agent_info <- artifact_test_agent(withr::local_tempdir())
+  agent_info$external_regressors <- "price"
+  artifact_test_eda(agent_info)
+  original_read <- read_file
+  testthat::local_mocked_bindings(
+    check_agent_info = function(...) invisible(NULL),
+    read_file = function(run_info, path = NULL, file_list = NULL, ...) {
+      data <- original_read(run_info, path = path, file_list = file_list, ...)
+      if (!is.null(file_list) && is.data.frame(data) && "Combo" %in% names(data)) {
+        data <- dplyr::filter(data, Combo != "B")
+      }
+      data
+    },
+    .package = "finnts"
+  )
+
+  save_eda_data(agent_info)
+  result <- get_eda_data(agent_info) %>% dplyr::arrange(Combo, Analysis_Type, Metric)
+
+  expect_false("B" %in% result$Combo)
+  expect_failure(expect_equal(result, artifact_expected_eda()))
+})
+
+test_that("forecast getter reads discovered condensed files without listing again", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  artifact_test_log(run_info, combo_variables = "ID", forecast_approach = "bottoms_up")
+  artifact_test_splits(run_info)
+  forecast <- artifact_test_forecast(run_info)
+  write_data(forecast, "batch_1", run_info, "data", "forecasts", "-condensed")
+  tracker <- local_artifact_spies(max_listings = 1L)
+
+  result <- get_forecast_data(run_info)
+
+  expect_equal(result$Forecast, forecast$Forecast)
+  expect_identical(result$Combo, "A")
+  expect_equal(tracker$listings, 1L)
+})
+
+test_that("hierarchy consumes its discovered condensed filenames directly", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  artifact_test_splits(run_info)
+  forecast <- artifact_test_forecast(run_info)
+  write_data(forecast, "batch_1", run_info, "data", "forecasts", "-condensed")
+  write_data(list(nodes = 1, original_combos = "A", hts_combos = "A"),
+    NULL, run_info, "object", "prep_data", "-hts_info"
+  )
+  tracker <- local_artifact_spies(max_listings = 1L)
+  testthat::local_mocked_bindings(
+    validate_best_model = function(...) stop("hierarchy inputs verified", call. = FALSE),
+    .package = "finnts"
+  )
+
+  expect_error(reconcile_hierarchical_data(run_info, NULL, "standard_hierarchy",
+    date_type = "month", num_cores = 1
+  ), "hierarchy inputs verified")
+  expect_equal(tracker$listings, 1L)
+})
+
+test_that("model preparation shares one lazily discovered recipe inventory", {
+  run_info <- set_run_info(
+    project_name = "artifact_prep", run_name = "test",
+    path = withr::local_tempdir(), add_unique_id = FALSE
+  )
+  data <- tibble::tibble(
+    id = "A", Date = seq.Date(as.Date("2020-01-01"), by = "month", length.out = 36),
+    value = 100 + seq_len(36)
+  )
+  prep_data(run_info, data, combo_variables = "id", target_variable = "value",
+    date_type = "month", forecast_horizon = 2, recipes_to_run = "R1"
+  )
+  tracker <- local_artifact_spies(max_listings = 1L)
+
+  prep_models(run_info, models_to_run = "meanf", back_test_scenarios = 1,
+    num_hyperparameters = 1, run_ensemble_models = FALSE
+  )
+  expect_equal(tracker$listings, 1L)
+  expect_setequal(get_prepped_models(run_info)$Type,
+    c("Model_Workflows", "Model_Hyperparameters", "Train_Test_Splits")
+  )
+  prep_models(run_info, models_to_run = "meanf", back_test_scenarios = 1,
+    num_hyperparameters = 1, run_ensemble_models = FALSE
+  )
+  expect_equal(tracker$listings, 1L)
+})
+
+test_that("supplied aggregate inventory is filtered without rediscovery or extra recipes", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  paths <- character()
+  for (combo in c("A", "B")) {
+    for (recipe in c("R1", "R2")) {
+      artifact_test_recipe(run_info, combo, recipe)
+      paths <- c(paths, as.character(artifact_test_path(run_info, "prep_data", combo, paste0("-", recipe))))
+    }
+  }
+  tracker <- local_artifact_spies()
+
+  result <- get_recipe_data(run_info, "All-Data", recipes = "R2", file_list = paths)
+
+  expect_identical(result$Recipe, "R2")
+  expect_setequal(result$Data[[1]]$Combo, c("A", "B"))
+  expect_length(tracker$reads, 1L)
+  expect_equal(tracker$listings, 0L)
+})

--- a/tests/testthat/test-artifact-discovery-reuse.R
+++ b/tests/testthat/test-artifact-discovery-reuse.R
@@ -50,6 +50,48 @@ test_that("EDA consolidation reuses one discovery for every analysis type", {
   expect_equal(tracker$directory_listings, 1L)
 })
 
+for (storage_class in c("blob_container", "ms_drive")) {
+  test_that(paste("provider EDA consolidation avoids input discovery for", storage_class), {
+    agent_info <- artifact_test_agent(withr::local_tempdir())
+    agent_info$external_regressors <- "price"
+    artifact_test_eda(agent_info)
+    agent_info$project_info$storage_object <- structure(list(), class = storage_class)
+    original_list <- list_files
+    original_read <- read_file
+    original_write <- write_data
+    provider_listings <- character()
+    testthat::local_mocked_bindings(
+      check_agent_info = function(...) invisible(NULL),
+      list_files = function(storage_object, path, ...) {
+        if (!is.null(storage_object)) provider_listings <<- c(provider_listings, path)
+        if (grepl("/input_data/", path, fixed = TRUE)) {
+          stop("Unexpected input-data listing during EDA consolidation", call. = FALSE)
+        }
+        original_list(NULL, path, ...)
+      },
+      read_file = function(run_info, ...) {
+        run_info$storage_object <- NULL
+        original_read(run_info, ...)
+      },
+      write_data = function(x, combo, run_info, ...) {
+        run_info$storage_object <- NULL
+        original_write(x, combo, run_info, ...)
+      },
+      download_file = function(...) stop("Unexpected provider download", call. = FALSE),
+      .package = "finnts"
+    )
+
+    save_eda_data(agent_info)
+    result <- get_eda_data(agent_info) %>% dplyr::arrange(Combo, Analysis_Type, Metric)
+
+    expect_equal(result, artifact_expected_eda())
+    expect_equal(nrow(result), 38L)
+    expect_equal(anyDuplicated(result[c("Combo", "Analysis_Type", "Metric")]), 0L)
+    expect_length(provider_listings, 7L)
+    expect_false(any(grepl("/input_data/", provider_listings, fixed = TRUE)))
+  })
+}
+
 test_that("independent EDA expectations reject a dropped-series mutation", {
   agent_info <- artifact_test_agent(withr::local_tempdir())
   agent_info$external_regressors <- "price"

--- a/tests/testthat/test-artifact-io-parallel.R
+++ b/tests/testthat/test-artifact-io-parallel.R
@@ -1,0 +1,282 @@
+test_that("PSOCK workers read independent exact recipe paths without enumeration", {
+  run_info <- artifact_test_run(withr::local_tempdir(), "rds")
+  for (combo in c("A", "B")) {
+    for (recipe in c("R1", "R2")) artifact_test_recipe(run_info, combo, recipe)
+  }
+  jobs <- lapply(c("A", "B"), function(combo) {
+    list(run_info = run_info, combo = hash_data(combo), recipes = c("R1", "R2"))
+  })
+  before <- serialize(jobs, NULL)
+  expected <- lapply(jobs, function(job) {
+    get_recipe_data(job$run_info, job$combo, recipes = job$recipes)
+  })
+  cluster <- parallel::makePSOCKcluster(2)
+  on.exit(parallel::stopCluster(cluster), add = TRUE)
+  package_path <- getNamespaceInfo(asNamespace("finnts"), "path")
+  definitions <- NULL
+  if (!file.exists(file.path(package_path, "Meta", "package.rds"))) {
+    symbols <- c("get_recipe_data", "read_local_artifacts", "local_artifact_files",
+      "local_artifact_path", "read_file", "hash_data", "get_recipes_to_run")
+    definitions <- setNames(lapply(symbols, function(symbol) {
+      definition <- getFromNamespace(symbol, "finnts")
+      environment(definition) <- baseenv()
+      definition
+    }), symbols)
+  }
+  bootstrap <- function(libraries, definitions) {
+    .libPaths(libraries)
+    worker_environment <- asNamespace("finnts")
+    if (!is.null(definitions)) {
+      worker_environment <- new.env(parent = worker_environment)
+      for (symbol in names(definitions)) {
+        definition <- definitions[[symbol]]
+        environment(definition) <- worker_environment
+        assign(symbol, definition, envir = worker_environment)
+      }
+      worker_environment$list_files <- function(...) {
+        stop("worker enumerated a directory", call. = FALSE)
+      }
+    }
+    assign("finnts_artifact_test_environment", worker_environment, envir = globalenv())
+    TRUE
+  }
+  environment(bootstrap) <- baseenv()
+  parallel::clusterCall(cluster, bootstrap, .libPaths(), definitions)
+
+  result <- parallel::parLapply(cluster, jobs, function(job) {
+    testthat::local_mocked_bindings(
+      list_files = function(...) stop("worker enumerated a directory", call. = FALSE),
+      .package = "finnts"
+    )
+    worker_environment <- get("finnts_artifact_test_environment", envir = globalenv())
+    worker_environment$get_recipe_data(
+      job$run_info, job$combo, recipes = job$recipes
+    )
+  })
+
+  expect_equal(result, expected)
+  expect_identical(serialize(jobs, NULL), before)
+  expect_setequal(result[[1]]$Data[[1]]$Combo, "A")
+  expect_setequal(result[[2]]$Data[[1]]$Combo, "B")
+  missing_job <- jobs[[1]]
+  missing_job$combo <- hash_data("missing")
+  expect_error(parallel::parLapply(cluster, list(missing_job), function(job) {
+    worker_environment <- get("finnts_artifact_test_environment", envir = globalenv())
+    worker_environment$get_recipe_data(
+      job$run_info, job$combo, recipes = job$recipes
+    )
+  }), "Missing required Finn artifact")
+})
+
+test_that("Spark prepared-data routing continues to use path instead of file_list", {
+  run_info <- artifact_test_run(withr::local_tempdir(), "parquet")
+  run_info$combo <- hash_data("A")
+  observed <- list()
+  testthat::local_mocked_bindings(
+    read_file = function(run_info, path = NULL, file_list = NULL, return_type = "df", ...) {
+      observed[[length(observed) + 1L]] <<- list(path = path, file_list = file_list, return_type = return_type)
+      if (!is.null(file_list)) return(tibble::tibble(combo_variables = "ID"))
+      tibble::tibble(Combo = "A", Target = 1)
+    },
+    .package = "finnts"
+  )
+
+  result <- get_prepped_data(run_info, "R1", return_type = "sdf")
+
+  expect_identical(result$ID, "A")
+  expect_identical(observed[[2]]$return_type, "sdf")
+  expect_null(observed[[2]]$file_list)
+  expect_match(observed[[2]]$path, "*", fixed = TRUE)
+})
+
+test_that("Spark forecast routing retains its bulk path contract", {
+  run_info <- artifact_test_run(withr::local_tempdir(), "parquet")
+  run_info$combo <- hash_data("A")
+  forecast <- artifact_test_forecast(run_info, write_output = FALSE)
+  observed <- list()
+  testthat::local_mocked_bindings(
+    list_files = function(...) character(),
+    read_file = function(run_info, path = NULL, file_list = NULL, return_type = "df", ...) {
+      observed[[length(observed) + 1L]] <<- list(path = path, file_list = file_list, return_type = return_type)
+      if (!is.null(file_list)) {
+        return(tibble::tibble(combo_variables = "ID", forecast_approach = "bottoms_up"))
+      }
+      if (grepl("train_test_split", path, fixed = TRUE)) {
+        return(tibble::tibble(Run_Type = "Future_Forecast", Train_Test_ID = 1))
+      }
+      forecast
+    },
+    .package = "finnts"
+  )
+
+  result <- get_forecast_data(run_info, return_type = "sdf")
+
+  expect_identical(result$Combo, "A")
+  expect_identical(observed[[3]]$return_type, "sdf")
+  expect_null(observed[[3]]$file_list)
+  expect_match(observed[[3]]$path, "*", fixed = TRUE)
+})
+
+test_that("provider recipe routing retains its original discovery and download path", {
+  run_info <- artifact_test_run("provider-root")
+  run_info$storage_object <- structure(list(), class = "blob_container")
+  recipe_path <- artifact_test_path(run_info, "prep_data", "A", "-R1")
+  listings <- 0L
+  observed <- NULL
+  testthat::local_mocked_bindings(
+    list_files = function(...) {
+      listings <<- listings + 1L
+      recipe_path
+    },
+    read_file = function(run_info, path = NULL, file_list = NULL, ...) {
+      observed <<- list(path = path, file_list = file_list)
+      tibble::tibble(Combo = "A", Target = 1)
+    },
+    .package = "finnts"
+  )
+
+  result <- get_recipe_data(run_info, hash_data("A"))
+
+  expect_identical(result$Recipe, "R1")
+  expect_equal(listings, 1L)
+  expect_null(observed$file_list)
+  expect_match(observed$path, "/prep_data/", fixed = TRUE)
+})
+
+test_that("installed train_models dispatches exact recipe reads to real PSOCK workers", {
+  package_path <- getNamespaceInfo(asNamespace("finnts"), "path")
+  skip_if_not(file.exists(file.path(package_path, "Meta", "package.rds")),
+    "Actual training dispatch is verified from the installed namespace"
+  )
+  withr::local_envvar(c(R_LIBS = paste(.libPaths(), collapse = .Platform$path.sep)))
+  template <- set_run_info(project_name = "artifact_dispatch", run_name = "test",
+    path = withr::local_tempdir(), data_output = "csv", object_output = "rds", add_unique_id = FALSE
+  )
+  data <- tibble::tibble(
+    id = rep(c("A", "B"), each = 36),
+    Date = rep(seq.Date(as.Date("2020-01-01"), by = "month", length.out = 36), 2),
+    value = c(100 + seq_len(36), 300 + 3 * seq_len(36))
+  )
+  prep_data(template, data, combo_variables = "id", target_variable = "value",
+    date_type = "month", forecast_horizon = 2, recipes_to_run = "R1"
+  )
+  prep_models(template, models_to_run = "meanf", back_test_scenarios = 1,
+    num_hyperparameters = 1, run_ensemble_models = FALSE
+  )
+  copy_template <- function(path, include_recipes = TRUE) {
+    info <- template
+    info$path <- path
+    folders <- c("logs", "prep_models", if (include_recipes) "prep_data")
+    for (folder in folders) fs::dir_copy(fs::path(template$path, folder), fs::path(path, folder))
+    fs::dir_create(fs::path(path, c("forecasts", "models", "prep_data")))
+    if (!include_recipes) {
+      fs::file_copy(artifact_test_path(template, "prep_data", suffix = "-orig_combo_info"),
+        artifact_test_path(info, "prep_data", suffix = "-orig_combo_info"))
+    }
+    info
+  }
+  sequential_info <- copy_template(withr::local_tempdir())
+  parallel_info <- copy_template(withr::local_tempdir())
+  missing_info <- copy_template(withr::local_tempdir(), include_recipes = FALSE)
+  missing_info$combo <- hash_data("A")
+  train_models(sequential_info, run_global_models = FALSE, run_local_models = TRUE, num_cores = 2)
+
+  install_guard <- function(root) {
+    asNamespace("finnts")
+    tracker <- new.env(parent = emptyenv())
+    tracker$recipe_reads <- character()
+    tracker$listings <- 0L
+    root <- paste0(gsub("\\", "/", root, fixed = TRUE), "/")
+    original_dir_ls <- fs::dir_ls
+    original_list_files <- list.files
+    original_read <- vroom::vroom
+    record_directory <- function(path) {
+      if (any(startsWith(paste0(gsub("\\", "/", as.character(path), fixed = TRUE), "/"), root))) {
+        tracker$listings <- tracker$listings + 1L
+        stop("training worker enumerated an artifact directory", call. = FALSE)
+      }
+    }
+    testthat::local_mocked_bindings(
+      dir_ls = function(path = ".", ...) {
+        record_directory(path)
+        original_dir_ls(path, ...)
+      },
+      .package = "fs", .env = globalenv()
+    )
+    testthat::local_mocked_bindings(
+      list.files = function(path = ".", ...) {
+        record_directory(path)
+        original_list_files(path, ...)
+      },
+      .package = "base", .env = globalenv()
+    )
+    testthat::local_mocked_bindings(
+      vroom = function(file, ...) {
+        if (is.character(file)) {
+          paths <- gsub("\\", "/", as.character(file), fixed = TRUE)
+          tracker$recipe_reads <- c(tracker$recipe_reads,
+            paths[startsWith(paths, root) & grepl("-R[12]\\.csv$", paths)])
+        }
+        original_read(file, ...)
+      },
+      .package = "vroom", .env = globalenv()
+    )
+    assign("finnts_training_io", tracker, envir = globalenv())
+    TRUE
+  }
+  environment(install_guard) <- baseenv()
+  collect_guard <- function() {
+    tracker <- get("finnts_training_io", envir = globalenv())
+    list(pid = Sys.getpid(), recipe_reads = tracker$recipe_reads, listings = tracker$listings)
+  }
+  environment(collect_guard) <- baseenv()
+  original_start <- par_start
+  original_end <- par_end
+  clusters <- list()
+  reports <- list()
+  on.exit({
+    for (cluster in clusters) try(parallel::stopCluster(cluster), silent = TRUE)
+    foreach::registerDoSEQ()
+  }, add = TRUE)
+  testthat::local_mocked_bindings(
+    par_start = function(run_info, ...) {
+      info <- original_start(run_info, ...)
+      if (inherits(info$cl, "cluster")) {
+        clusters[[length(clusters) + 1L]] <<- info$cl
+        parallel::clusterCall(info$cl, install_guard, run_info$path)
+      }
+      info
+    },
+    par_end = function(cl) {
+      if (inherits(cl, "cluster")) reports <<- c(reports, parallel::clusterCall(cl, collect_guard))
+      original_end(cl)
+    },
+    .package = "finnts"
+  )
+
+  train_models(parallel_info, run_global_models = FALSE, run_local_models = TRUE,
+    parallel_processing = "local_machine", num_cores = 2
+  )
+
+  expect_length(reports, 2L)
+  expect_equal(length(unique(vapply(reports, function(report) report$pid, integer(1)))), 2L)
+  expect_equal(sum(vapply(reports, function(report) report$listings, integer(1))), 0L)
+  recipe_reads <- unlist(lapply(reports, function(report) report$recipe_reads), use.names = FALSE)
+  expect_setequal(recipe_reads, vapply(c("A", "B"), function(combo) {
+    as.character(artifact_test_path(parallel_info, "prep_data", combo, "-R1"))
+  }, character(1)))
+  expect_length(recipe_reads, 2L)
+  for (combo in c("A", "B")) {
+    expected <- read_file(sequential_info,
+      file_list = artifact_test_path(sequential_info, "forecasts", combo, "-single_models"), strict = TRUE)
+    actual <- read_file(parallel_info,
+      file_list = artifact_test_path(parallel_info, "forecasts", combo, "-single_models"), strict = TRUE)
+    expect_equal(actual, expected)
+    expected_models <- readRDS(artifact_test_path(sequential_info, "models", combo, "-single_models", "rds"))
+    actual_models <- readRDS(artifact_test_path(parallel_info, "models", combo, "-single_models", "rds"))
+    expect_equal(dplyr::select(actual_models, -Model_Fit), dplyr::select(expected_models, -Model_Fit))
+  }
+  expect_error(train_models(missing_info, run_global_models = FALSE, run_local_models = TRUE,
+    parallel_processing = "local_machine", num_cores = 2
+  ), "Missing required Finn artifact.*R1")
+})

--- a/tests/testthat/test-artifact-restarts.R
+++ b/tests/testthat/test-artifact-restarts.R
@@ -1,0 +1,149 @@
+test_that("completed local ensembles skip without enumerating forecasts", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  run_info$combo <- hash_data("A")
+  artifact_test_model_log(run_info)
+  artifact_test_splits(run_info)
+  artifact_test_forecast(run_info)
+  artifact_test_forecast(run_info, suffix = "ensemble_models")
+  tracker <- local_artifact_spies()
+  testthat::local_mocked_bindings(
+    par_start = function(...) stop("completed ensemble was dispatched", call. = FALSE),
+    .package = "finnts"
+  )
+
+  expect_no_error(ensemble_models(run_info))
+  expect_equal(tracker$listings, 0L)
+})
+
+test_that("unfinished local ensembles dispatch without directory enumeration", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  run_info$combo <- hash_data("A")
+  artifact_test_model_log(run_info)
+  artifact_test_splits(run_info)
+  artifact_test_forecast(run_info)
+  tracker <- local_artifact_spies()
+  testthat::local_mocked_bindings(
+    par_start = function(...) stop("unfinished ensemble dispatched", call. = FALSE),
+    .package = "finnts"
+  )
+
+  expect_error(ensemble_models(run_info), "unfinished ensemble dispatched")
+  expect_equal(tracker$listings, 0L)
+})
+
+test_that("ensemble completion counts persisted outputs instead of worker returns", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  run_info$combo <- hash_data("A")
+  artifact_test_model_log(run_info)
+  artifact_test_splits(run_info)
+  artifact_test_forecast(run_info)
+  artifact_test_forecast(run_info, combo = "unrelated", suffix = "ensemble_models")
+  tracker <- local_artifact_spies()
+  testthat::local_mocked_bindings(
+    par_start = function(...) list(cl = NULL, packages = character(),
+      foreach_operator = function(...) data.frame(Combo = hash_data("A"))),
+    par_end = function(...) invisible(NULL),
+    .package = "finnts"
+  )
+
+  expect_message(ensemble_models(run_info), "expected 1.*only 0")
+  expect_equal(tracker$listings, 0L)
+})
+
+test_that("completed hierarchy restart reuses discovery and checks the exact reconciliation", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  artifact_test_model_log(run_info, "standard_hierarchy")
+  artifact_test_splits(run_info)
+  artifact_test_forecast(run_info)
+  artifact_test_forecast(run_info, suffix = "average_models")
+  write_data(tibble::tibble(value = 1), "Best-Model", run_info, "data", "forecasts", "-reconciled")
+  tracker <- local_artifact_spies(max_listings = 1L)
+  testthat::local_mocked_bindings(
+    reconcile_hierarchical_data = function(...) stop("completed reconciliation reran", call. = FALSE),
+    .package = "finnts"
+  )
+
+  expect_no_error(final_models(run_info))
+  expect_equal(tracker$listings, 1L)
+})
+
+test_that("missing reconciliation is not satisfied by another run output", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  artifact_test_model_log(run_info, "standard_hierarchy")
+  artifact_test_splits(run_info)
+  artifact_test_forecast(run_info)
+  artifact_test_forecast(run_info, suffix = "average_models")
+  write_data(tibble::tibble(value = 1), "unrelated", run_info, "data", "forecasts", "-reconciled")
+  tracker <- local_artifact_spies(max_listings = 1L)
+  testthat::local_mocked_bindings(
+    reconcile_hierarchical_data = function(...) stop("missing reconciliation dispatched", call. = FALSE),
+    .package = "finnts"
+  )
+
+  expect_error(final_models(run_info), "missing reconciliation dispatched")
+  expect_equal(tracker$listings, 1L)
+})
+
+local_artifact_logger <- function(agent_info, run_info, .env = parent.frame()) {
+  log <- tibble::tibble(project_name = run_info$project_name, run_name = run_info$run_name,
+    path = run_info$path, data_output = run_info$data_output, object_output = run_info$object_output,
+    weighted_mape = 0.1, created = "2024-01-01 00:00:00"
+  )
+  forecasts <- tibble::tibble(Combo = c("A", "B"), Target = 100, Forecast = c(90, 110),
+    Best_Model = "Yes", Run_Type = "Back_Test"
+  )
+  testthat::local_mocked_bindings(
+    get_run_info = function(...) log,
+    load_combo_forecast = function(...) forecasts,
+    .package = "finnts", .env = .env
+  )
+}
+
+test_that("global best-run verification reads the expected files directly", {
+  agent_info <- artifact_test_agent(withr::local_tempdir())
+  agent_info$agent_version <- 1
+  agent_info$forecast_approach <- "bottoms_up"
+  run_info <- agent_info$project_info
+  run_info$run_name <- "candidate"
+  local_artifact_logger(agent_info, run_info)
+  tracker <- local_artifact_spies()
+
+  expect_identical(log_best_run(agent_info, run_info, 0.1, check_best_run = FALSE),
+    "Run logged successfully."
+  )
+  expect_equal(tracker$listings, 0L)
+  for (combo in c("A", "B")) {
+    path <- artifact_test_path(
+      agent_info$project_info, "logs", combo, "-agent_best_run", "csv"
+    )
+    expect_true(fs::file_exists(path))
+    expect_equal(sum(tracker$metadata_paths == as.character(path)), 1L)
+    expect_equal(sum(tracker$access_paths == as.character(path)), 1L)
+  }
+})
+
+test_that("missing best-run writes cannot be masked by unrelated files", {
+  agent_info <- artifact_test_agent(withr::local_tempdir())
+  agent_info$agent_version <- 1
+  agent_info$forecast_approach <- "bottoms_up"
+  run_info <- agent_info$project_info
+  run_info$run_name <- "candidate"
+  write_data(tibble::tibble(combo = "unrelated"), "unrelated", agent_info$project_info,
+    "log", "logs", "-agent_best_run"
+  )
+  local_artifact_logger(agent_info, run_info)
+  original_write <- write_data
+  testthat::local_mocked_bindings(
+    write_data = function(x, combo, run_info, output_type, folder = NULL, suffix = NULL) {
+      if (identical(combo, "B") && identical(suffix, "-agent_best_run")) return(invisible(NULL))
+      original_write(x, combo, run_info, output_type, folder, suffix)
+    },
+    .package = "finnts"
+  )
+  tracker <- local_artifact_spies()
+
+  expect_error(log_best_run(agent_info, run_info, 0.1, check_best_run = FALSE),
+    "Expected 2.*only found 1"
+  )
+  expect_equal(tracker$listings, 0L)
+})

--- a/tests/testthat/test-direct-artifact-reads.R
+++ b/tests/testthat/test-direct-artifact-reads.R
@@ -1,0 +1,393 @@
+for (format in c("csv", "parquet", "rds")) {
+  test_that(paste("single-combo prepared-data getters avoid discovery for", format), {
+    if (format == "parquet") skip_if_not_installed("arrow")
+    run_info <- artifact_test_run(withr::local_tempdir(), format)
+    run_info$combo <- hash_data("A")
+    artifact_test_log(run_info, "R2", combo_variables = "ID")
+    expected <- artifact_test_recipe(run_info, "A", "R2")
+    tracker <- local_artifact_spies()
+
+    result <- get_prepped_data(run_info, "R2")
+
+    expect_equal(result$Target, expected$Target)
+    expect_identical(result$ID, rep("A", 3))
+    expect_equal(tracker$listings, 0L)
+  })
+}
+
+test_that("single-combo forecast getter retains every existing model output", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  artifact_test_log(run_info, combo_variables = "ID", forecast_approach = "bottoms_up")
+  artifact_test_splits(run_info)
+  artifact_test_forecast(run_info)
+  artifact_test_forecast(run_info, suffix = "ensemble_models", model = "ensemble", best = "No")
+  artifact_test_forecast(run_info, suffix = "average_models", model = "average", best = "No")
+  expected <- get_forecast_data(run_info)
+  run_info$combo <- hash_data("A")
+  tracker <- local_artifact_spies(max_listings = 1L)
+
+  result <- get_forecast_data(run_info)
+
+  expect_equal(result, expected)
+  expect_equal(tracker$listings, 1L)
+})
+
+test_that("trained model getter reads exactly the known combo model files", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  run_info$combo <- hash_data("A")
+  for (suffix in c("single_models", "ensemble_models")) {
+    write_data(tibble::tibble(Model_ID = suffix, Model_Fit = list(list(value = 1))),
+      "A", run_info, "object", "models", paste0("-", suffix)
+    )
+  }
+  write_data(tibble::tibble(Model_ID = "unrelated"), "B", run_info, "object", "models", "-single_models")
+  tracker <- local_artifact_spies()
+
+  result <- get_trained_models(run_info)
+
+  expect_setequal(result$Model_ID, c("single_models", "ensemble_models"))
+  expect_equal(tracker$listings, 0L)
+  expect_length(tracker$reads, 1L)
+})
+
+test_that("temporary roots support named logs and prepared-data getters", {
+  run_info <- artifact_test_run(NULL)
+  run_info$combo <- hash_data("A")
+  expected_log <- artifact_test_log(run_info, combo_variables = "ID")
+  expected <- artifact_test_recipe(run_info, "A", "R1")
+  tracker <- local_artifact_spies()
+
+  result_log <- get_run_info(run_info$project_name, run_info$run_name, path = NULL)
+  result <- get_prepped_data(run_info, "R1")
+
+  expect_equal(result_log, expected_log)
+  expect_equal(result$Target, expected$Target)
+  expect_equal(tracker$listings, 0L)
+})
+
+for (format in c("csv", "parquet", "rds")) {
+  test_that(paste("exact table reads combine only supplied files for", format), {
+    if (format == "parquet") skip_if_not_installed("arrow")
+    root <- fs::path(withr::local_tempdir(), "synfs", paste0("mount ", intToUtf8(233)))
+    run_info <- artifact_test_run(root, format)
+    expected <- dplyr::bind_rows(
+      artifact_test_recipe(run_info, "A", "R1", 10),
+      artifact_test_recipe(run_info, "B", "R1", 20)
+    )
+    paths <- vapply(c("A", "B"), function(combo) {
+      as.character(artifact_test_path(run_info, "prep_data", combo, "-R1"))
+    }, character(1))
+    tracker <- local_artifact_spies()
+
+    result <- read_local_artifacts(run_info, paths)
+
+    expect_equal(result, expected)
+    expect_equal(tracker$listings, 0L)
+    expect_length(tracker$reads, 1L)
+  })
+}
+
+test_that("missing required and optional artifacts remain distinct", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  missing <- artifact_test_path(run_info, "prep_data", "A", "-R1")
+  tracker <- local_artifact_spies()
+
+  expect_error(read_local_artifacts(run_info, missing), "Missing required Finn artifact")
+  expect_error(read_local_artifacts(run_info, character()), "No files matched")
+  expect_equal(nrow(read_local_artifacts(run_info, missing, allow_missing = TRUE)), 0L)
+  expect_null(read_local_artifacts(run_info, missing, return_type = "object", allow_missing = TRUE))
+  expect_equal(tracker$listings, 0L)
+})
+
+test_that("empty CSV artifacts remain readable", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  for (contents in list(character(), "value")) {
+    path <- withr::local_tempfile(fileext = ".csv")
+    writeLines(contents, path)
+    expect_equal(nrow(suppressWarnings(read_local_artifacts(run_info, path))), 0L)
+  }
+})
+
+for (extension in c("rds", "parquet")) {
+  test_that(paste("corrupt binary artifacts fail for", extension), {
+    if (extension == "parquet") skip_if_not_installed("arrow")
+    run_info <- artifact_test_run(withr::local_tempdir())
+    path <- withr::local_tempfile(fileext = paste0(".", extension))
+    writeLines("not a valid binary artifact", path)
+    expect_error(read_local_artifacts(run_info, path))
+  })
+}
+
+test_that("optional artifacts do not hide read failures", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  artifact_test_recipe(run_info, "A", "R1")
+  path <- artifact_test_path(run_info, "prep_data", "A", "-R1")
+  testthat::local_mocked_bindings(
+    read_file = function(...) stop("permission denied", call. = FALSE),
+    .package = "finnts"
+  )
+
+  expect_error(read_local_artifacts(run_info, path, allow_missing = TRUE), "permission denied")
+})
+
+test_that("thousands of unrelated files do not affect known-combo reads", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  expected <- artifact_test_recipe(run_info, "A", "R1")
+  unrelated <- fs::path(run_info$path, "prep_data", paste0("unrelated-", seq_len(2500), ".csv"))
+  expect_true(all(file.create(unrelated)))
+  tracker <- local_artifact_spies()
+
+  result <- get_recipe_data(run_info, hash_data("A"), recipes = "R1")
+
+  expect_equal(result$Data[[1]], expected)
+  expect_equal(tracker$listings, 0L)
+  expect_length(tracker$reads, 1L)
+})
+
+test_that("optional artifact checks propagate metadata failures", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  missing <- artifact_test_path(run_info, "prep_data", "A", "-R1")
+  testthat::local_mocked_bindings(
+    file_info = function(...) stop("metadata permission denied", call. = FALSE),
+    .package = "fs"
+  )
+
+  expect_error(read_local_artifacts(run_info, missing, allow_missing = TRUE),
+    "metadata permission denied"
+  )
+})
+
+test_that("empty combo selections do not manufacture a singleton path", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+
+  expect_length(local_artifact_path(run_info, "models", "-model_summary", character()), 0L)
+})
+
+test_that("prepared-model metadata is read correctly from the default temporary root", {
+  run_info <- artifact_test_run(NULL, "rds")
+  writer_info <- run_info
+  writer_info$path <- tempdir()
+  for (suffix in c("-train_test_split", "-model_hyperparameters", "-model_workflows")) {
+    write_data(tibble::tibble(value = 1), NULL, writer_info, "object", "prep_models", suffix)
+  }
+  tracker <- local_artifact_spies()
+
+  result <- get_prepped_models(run_info)
+
+  expect_setequal(result$Type, c("Model_Workflows", "Model_Hyperparameters", "Train_Test_Splits"))
+  expect_true(all(vapply(result$Data, function(data) identical(data$value, 1), logical(1))))
+  expect_length(tracker$reads, 3L)
+})
+
+test_that("single-combo forecast getters preserve condensed-output precedence", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  run_info$combo <- hash_data("A")
+  artifact_test_log(run_info, combo_variables = "ID", forecast_approach = "bottoms_up")
+  artifact_test_splits(run_info)
+  condensed <- artifact_test_forecast(run_info)
+  condensed$Forecast <- 200
+  write_data(condensed, "batch_1", run_info, "data", "forecasts", "-condensed")
+  tracker <- local_artifact_spies(max_listings = 1L)
+
+  result <- get_forecast_data(run_info)
+
+  expect_equal(result$Forecast, 200)
+  expect_equal(tracker$listings, 1L)
+})
+
+test_that("single-combo forecast getters can read condensed-only output", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  run_info$combo <- hash_data("A")
+  artifact_test_log(run_info, combo_variables = "ID", forecast_approach = "bottoms_up")
+  artifact_test_splits(run_info)
+  source_run <- artifact_test_run(withr::local_tempdir())
+  condensed <- artifact_test_forecast(source_run)
+  write_data(condensed, "batch_1", run_info, "data", "forecasts", "-condensed")
+  tracker <- local_artifact_spies(max_listings = 1L)
+
+  result <- get_forecast_data(run_info)
+
+  expect_equal(result$Forecast, condensed$Forecast)
+  expect_equal(tracker$listings, 1L)
+})
+
+test_that("directories at artifact paths are hard errors even when optional", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  directory <- artifact_test_path(run_info, "prep_data", "A", "-R1")
+  fs::dir_create(directory)
+
+  expect_error(read_local_artifacts(run_info, directory, allow_missing = TRUE),
+    "not a regular file"
+  )
+})
+
+test_that("strict local CSV reads propagate unavailable metadata after preflight", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  artifact_test_recipe(run_info, "A", "R1")
+  path <- artifact_test_path(run_info, "prep_data", "A", "-R1")
+  testthat::local_mocked_bindings(
+    vroom = function(...) stop("injected CSV read failure", call. = FALSE),
+    .package = "vroom"
+  )
+  testthat::local_mocked_bindings(
+    file.info = function(...) data.frame(size = NA_real_),
+    .package = "base"
+  )
+
+  expect_error(read_local_artifacts(run_info, path), "Cannot read Finn CSV artifact")
+  expect_error(read_local_artifacts(run_info, path, allow_missing = TRUE),
+    "Cannot read Finn CSV artifact"
+  )
+  expect_equal(nrow(read_file(run_info, file_list = path)), 0L)
+})
+
+test_that("strict local CSV reads propagate fallback read errors", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  artifact_test_recipe(run_info, "A", "R1")
+  path <- artifact_test_path(run_info, "prep_data", "A", "-R1")
+  testthat::local_mocked_bindings(
+    vroom = function(...) stop("injected CSV read failure", call. = FALSE),
+    .package = "vroom"
+  )
+  testthat::local_mocked_bindings(
+    read.csv = function(...) stop("injected fallback permission error", call. = FALSE),
+    .package = "utils"
+  )
+
+  expect_error(read_local_artifacts(run_info, path), "injected fallback permission error")
+  expect_warning(legacy <- read_file(run_info, file_list = path),
+    "Skipping empty or unreadable file"
+  )
+  expect_equal(nrow(legacy), 0L)
+})
+
+test_that("strict local multi-file reads cannot silently lose a failed CSV", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  artifact_test_recipe(run_info, "A", "R1")
+  artifact_test_recipe(run_info, "B", "R1")
+  paths <- c(
+    artifact_test_path(run_info, "prep_data", "A", "-R1"),
+    artifact_test_path(run_info, "prep_data", "B", "-R1")
+  )
+  original_info <- file.info
+  testthat::local_mocked_bindings(
+    vroom = function(...) stop("injected multi-file read failure", call. = FALSE),
+    .package = "vroom"
+  )
+  testthat::local_mocked_bindings(
+    file.info = function(path, ...) {
+      if (identical(as.character(path), as.character(paths[[2]]))) {
+        return(data.frame(size = NA_real_))
+      }
+      original_info(path, ...)
+    },
+    .package = "base"
+  )
+
+  expect_error(read_local_artifacts(run_info, paths), "Cannot read Finn CSV artifact")
+  expect_identical(unique(read_file(run_info, file_list = paths)$Combo), "A")
+})
+
+test_that("later condensed batches take precedence even when batch one is absent", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  run_info$combo <- hash_data("A")
+  artifact_test_log(run_info, combo_variables = "ID", forecast_approach = "bottoms_up")
+  artifact_test_splits(run_info)
+  condensed <- artifact_test_forecast(run_info)
+  condensed$Forecast <- 200
+  write_data(condensed, "batch_2", run_info, "data", "forecasts", "-condensed")
+  tracker <- local_artifact_spies(max_listings = 1L)
+
+  result <- get_forecast_data(run_info)
+
+  expect_equal(result$Forecast, 200)
+  expect_equal(tracker$listings, 1L)
+})
+
+test_that("condensed batches are consumed once regardless of discovery order", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  run_info$combo <- hash_data("A")
+  artifact_test_log(run_info, combo_variables = "ID", forecast_approach = "bottoms_up")
+  artifact_test_splits(run_info)
+  forecast <- artifact_test_forecast(run_info)
+  paths <- character()
+  for (batch in c(2L, 17L)) {
+    forecast$Forecast <- batch * 100
+    forecast$Date <- as.Date("2024-02-01") + batch
+    write_data(forecast, paste0("batch_", batch), run_info, "data", "forecasts", "-condensed")
+    paths <- c(paths, as.character(artifact_test_path(run_info, "forecasts",
+      paste0("batch_", batch), "-condensed")))
+  }
+  listing_calls <- 0L
+  testthat::local_mocked_bindings(
+    list_files = function(...) {
+      listing_calls <<- listing_calls + 1L
+      rev(paths)
+    },
+    .package = "finnts"
+  )
+  original_read <- read_file
+  read_paths <- character()
+  testthat::local_mocked_bindings(
+    read_file = function(run_info, path = NULL, file_list = NULL, ...) {
+      if (!is.null(path) && grepl("train_test_split", path, fixed = TRUE)) {
+        return(tibble::tibble(Run_Type = "Future_Forecast", Train_Test_ID = 1))
+      }
+      read_paths <<- c(read_paths, as.character(file_list))
+      original_read(run_info, path, file_list, ...)
+    },
+    .package = "finnts"
+  )
+
+  result <- get_forecast_data(run_info)
+
+  expect_equal(result$Forecast, c(200, 1700))
+  expect_identical(listing_calls, 1L)
+  expect_equal(sum(read_paths %in% paths), 2L)
+  expect_equal(anyDuplicated(read_paths[read_paths %in% paths]), 0L)
+})
+
+test_that("known model candidates are validated once and read once", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  run_info$combo <- hash_data("A")
+  write_data(tibble::tibble(Model_ID = "meanf", Model_Fit = list(list(value = 1))),
+    "A", run_info, "object", "models", "-single_models"
+  )
+  model_path <- as.character(artifact_test_path(run_info, "models", "A", "-single_models", "rds"))
+  tracker <- local_artifact_spies()
+
+  result <- get_trained_models(run_info)
+
+  expect_identical(result$Model_ID, "meanf")
+  expect_equal(sum(tracker$metadata_paths == model_path), 1L)
+  expect_equal(sum(tracker$access_paths == model_path), 1L)
+  expect_equal(sum(tracker$payload_paths == model_path), 1L)
+  expect_length(tracker$metadata_paths, 4L)
+  expect_equal(tracker$directory_listings, 0L)
+})
+
+test_that("the I/O spy rejects direct directory enumeration outside list_files", {
+  directory <- fs::path(withr::local_tempdir(), "prep_data")
+  fs::dir_create(directory)
+  tracker <- local_artifact_spies()
+
+  expect_error(fs::dir_ls(directory), "Unexpected low-level directory enumeration")
+  expect_error(list.files(directory), "Unexpected low-level directory enumeration")
+  expect_error(dir(directory), "Unexpected low-level directory enumeration")
+  expect_error(list.dirs(directory), "Unexpected low-level directory enumeration")
+  expect_equal(tracker$listings, 0L)
+  expect_equal(tracker$directory_listings, 4L)
+})
+
+test_that("the I/O spy counts wrapper and filesystem discovery separately", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  artifact_test_recipe(run_info, "A", "R1")
+  tracker <- local_artifact_spies(max_listings = 1L)
+
+  files <- local_artifact_inventory(run_info, "prep_data", "-*R*")
+
+  expect_length(files, 1L)
+  expect_equal(tracker$listings, 1L)
+  expect_equal(tracker$directory_listings, 1L)
+  expect_identical(tracker$directory_calls[[1]]$api, "fs::dir_ls")
+})

--- a/tests/testthat/test-finalize_run.R
+++ b/tests/testthat/test-finalize_run.R
@@ -290,8 +290,9 @@ test_that("strict blob listing propagates storage provider failures", {
   expect_null(list_files(blob, "/logs/*.csv"))
 })
 
-test_that("global best-run write verification uses strict listing", {
+test_that("global provider best-run write verification uses strict listing", {
   agent_info <- make_finalize_agent_info(project_name = "strict_best_run_write")
+  agent_info$project_info$storage_object <- structure(list(), class = "blob_container")
   agent_info$agent_version <- 2
   agent_info$forecast_approach <- "bottoms_up"
   run_info <- agent_info$project_info

--- a/tests/testthat/test-read-write-data.R
+++ b/tests/testthat/test-read-write-data.R
@@ -59,3 +59,49 @@ test_that("read_file permits an explicitly optional missing table", {
   expect_s3_class(result, "data.frame")
   expect_equal(nrow(result), 0)
 })
+
+test_that("strict CSV fallback preserves valid empty and populated files", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  paths <- file.path(run_info$path, paste0("fallback-", seq_len(3), ".csv"))
+  file.create(paths[[1]])
+  writeLines("value", paths[[2]])
+  utils::write.csv(data.frame(value = c(2, 7)), paths[[3]], row.names = FALSE)
+  testthat::local_mocked_bindings(
+    vroom = function(...) stop("exercise compatible CSV fallback", call. = FALSE),
+    .package = "vroom"
+  )
+
+  strict_result <- read_file(run_info, file_list = paths, strict = TRUE)
+  legacy_result <- read_file(run_info, file_list = paths)
+
+  expect_equal(strict_result, tibble::tibble(value = c(2L, 7L)))
+  expect_equal(strict_result, legacy_result)
+  expect_equal(nrow(read_file(run_info, file_list = paths[1:2], strict = TRUE)), 0L)
+})
+
+test_that("strict CSV fallback keeps metadata exceptions as errors", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  artifact_test_recipe(run_info, "A", "R1")
+  path <- artifact_test_path(run_info, "prep_data", "A", "-R1")
+  original_info <- file.info
+  testthat::local_mocked_bindings(
+    vroom = function(...) stop("injected CSV read failure", call. = FALSE),
+    .package = "vroom"
+  )
+  testthat::local_mocked_bindings(
+    file.info = function(files, ...) {
+      if (any(as.character(files) == as.character(path))) {
+        stop("injected metadata I/O failure", call. = FALSE)
+      }
+      original_info(files, ...)
+    },
+    .package = "base"
+  )
+
+  expect_error(read_local_artifacts(run_info, path), "injected metadata I/O failure")
+  expect_error(read_local_artifacts(run_info, path, allow_missing = TRUE),
+    "injected metadata I/O failure")
+  expect_warning(legacy <- read_file(run_info, file_list = path),
+    "Skipping empty or unreadable file")
+  expect_equal(nrow(legacy), 0L)
+})

--- a/tests/testthat/test-recipe-artifact-reads.R
+++ b/tests/testthat/test-recipe-artifact-reads.R
@@ -1,0 +1,133 @@
+test_that("known combo recipes load directly and exclude other combos", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  artifact_test_log(run_info, c("R2", "R1"))
+  expected_r1 <- artifact_test_recipe(run_info, "A", "R1", 10)
+  expected_r2 <- artifact_test_recipe(run_info, "A", "R2", 20)
+  artifact_test_recipe(run_info, "B", "R1", 100)
+  tracker <- local_artifact_spies()
+
+  result <- get_recipe_data(run_info, combo = hash_data("A"))
+
+  expect_setequal(result$Recipe, c("R1", "R2"))
+  expect_equal(result$Data[[match("R1", result$Recipe)]], expected_r1)
+  expect_equal(result$Data[[match("R2", result$Recipe)]], expected_r2)
+  expect_equal(tracker$listings, 0L)
+  expect_length(tracker$reads, 3L)
+  expect_true(all(vapply(tracker$reads, function(read) {
+    is.null(read$path) && length(read$file_list) == 1L
+  }, logical(1))))
+  paths <- c(
+    artifact_test_path(run_info, "logs", extension = "csv"),
+    artifact_test_path(run_info, "prep_data", "A", "-R1"),
+    artifact_test_path(run_info, "prep_data", "A", "-R2")
+  )
+  expect_setequal(tracker$metadata_paths, as.character(paths))
+  expect_equal(anyDuplicated(tracker$metadata_paths), 0L)
+  expect_setequal(tracker$payload_paths, as.character(paths))
+  expect_equal(anyDuplicated(tracker$payload_paths), 0L)
+  expect_equal(tracker$directory_listings, 0L)
+})
+
+test_that("known combo recipe defaults follow the cadence", {
+  for (date_type in c("day", "week", "month", "quarter", "year")) {
+    run_info <- artifact_test_run(withr::local_tempdir())
+    artifact_test_log(run_info, NULL, date_type)
+    recipes <- get_recipes_to_run(NULL, date_type)
+    for (recipe in recipes) artifact_test_recipe(run_info, "A", recipe)
+    tracker <- local_artifact_spies()
+
+    result <- get_recipe_data(run_info, combo = hash_data("A"))
+
+    expect_setequal(result$Recipe, recipes)
+    expect_equal(tracker$listings, 0L, info = date_type)
+  }
+})
+
+test_that("R2-only recipes preserve already hashed Unicode combo identifiers", {
+  combo <- paste0("North ", intToUtf8(233), "--Retail")
+  run_info <- artifact_test_run(withr::local_tempdir())
+  run_info$combo <- hash_data(combo)
+  artifact_test_log(run_info, "R2")
+  expected <- artifact_test_recipe(run_info, combo, "R2")
+  tracker <- local_artifact_spies()
+
+  result <- get_recipe_data(run_info, combo = run_info$combo)
+
+  expect_identical(result$Recipe, "R2")
+  expect_equal(result$Data[[1]], expected)
+  expect_equal(tracker$listings, 0L)
+})
+
+test_that("missing configured recipes remain required artifacts", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  artifact_test_log(run_info, c("R1", "R2"))
+  artifact_test_recipe(run_info, "A", "R1")
+  tracker <- local_artifact_spies()
+
+  expect_error(
+    get_recipe_data(run_info, combo = hash_data("A")),
+    "Missing required Finn artifact.*R2"
+  )
+  expect_equal(tracker$listings, 0L)
+})
+
+test_that("All-Data recipe reads reuse one discovery result", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  for (combo in c("A", "B")) {
+    for (recipe in c("R1", "R2")) artifact_test_recipe(run_info, combo, recipe)
+  }
+  tracker <- local_artifact_spies(max_listings = 1L)
+
+  result <- get_recipe_data(run_info, combo = "All-Data")
+
+  expect_setequal(result$Recipe, c("R1", "R2"))
+  for (data in result$Data) expect_setequal(data$Combo, c("A", "B"))
+  expect_equal(tracker$listings, 1L)
+  expect_length(tracker$reads, 2L)
+  expect_true(all(vapply(tracker$reads, function(read) {
+    is.null(read$path) && length(read$file_list) == 2L
+  }, logical(1))))
+})
+
+test_that("supplied recipe metadata avoids another run log read", {
+  run_info <- artifact_test_run(withr::local_tempdir())
+  expected <- artifact_test_recipe(run_info, "A", "R1")
+  tracker <- local_artifact_spies()
+
+  result <- get_recipe_data(run_info, hash_data("A"), recipes = "R1")
+
+  expect_equal(result$Data[[1]], expected)
+  expect_length(tracker$reads, 1L)
+})
+
+test_that("training shares recipe metadata with every local worker", {
+  run_info <- set_run_info(
+    project_name = "artifact_training", run_name = "test",
+    path = withr::local_tempdir(), add_unique_id = FALSE
+  )
+  data <- tibble::tibble(
+    id = rep(c("A", "B"), each = 36),
+    Date = rep(seq.Date(as.Date("2020-01-01"), by = "month", length.out = 36), 2),
+    value = rep(100 + seq_len(36), 2)
+  )
+  prep_data(run_info, data, combo_variables = "id", target_variable = "value",
+    date_type = "month", forecast_horizon = 2, recipes_to_run = "R1"
+  )
+  prep_models(run_info, models_to_run = "meanf", back_test_scenarios = 1,
+    num_hyperparameters = 1, run_ensemble_models = FALSE
+  )
+  tracker <- local_artifact_spies(max_listings = 3L)
+
+  train_models(run_info, run_global_models = FALSE, run_local_models = TRUE)
+
+  log_reads <- vapply(tracker$reads, function(read) {
+    any(grepl("(^|/)logs/", paste0(read$path, read$file_list)))
+  }, logical(1))
+  expect_equal(sum(log_reads), 1L)
+  expect_equal(tracker$listings, 3L)
+  for (combo in c("A", "B")) {
+    expect_true(fs::file_exists(artifact_test_path(
+      run_info, "models", combo, "-single_models", run_info$object_output
+    )))
+  }
+})


### PR DESCRIPTION
This pull request implements a major improvement to artifact I/O efficiency and correctness, especially for local and ADLS-mounted workflows. The changes ensure that when the exact path of an artifact is known, the code reads files directly instead of performing unnecessary directory listings. This reduces overhead, avoids redundant operations, and improves reliability, particularly when working with large datasets or remote storage. Additionally, the update includes several targeted bug fixes and documentation updates to reflect the new artifact access best practices.

**Artifact I/O Improvements**

* Local and ADLS-mounted workflows now read known series inputs, recipes, EDA results, model outputs, and completion artifacts by exact path instead of directory enumeration. Directory listings are only performed for genuine discovery and are reused where possible. This change also ensures that valid empty CSVs and optional missing artifacts retain their supported behavior, while I/O failures propagate correctly. [[1]](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaL1-R5) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R62-R68)
* Refactored multiple functions in `R/agent_eda.R`, `R/agent_iterate_forecast.R`, `R/agent_update_forecast.R`, and `R/agent_summarize_models.R` to use direct path reads for known artifacts, replacing previous usage of `list_files()` with local artifact inventory and path helpers. [[1]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL69-R72) [[2]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL107-R112) [[3]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL141-R148) [[4]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL175-R184) [[5]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL211-R222) [[6]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL249-R262) [[7]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL295-R310) [[8]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL356-R373) [[9]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cR577-R588) [[10]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL604-R643) [[11]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL640-R682) [[12]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL676-R721) [[13]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL708-R756) [[14]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL739-R790) [[15]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL771-R825) [[16]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL831-R888) [[17]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL898-R954) [[18]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL1713-R1775) [[19]](diffhunk://#diff-d394bc7881d20f2b7d57d577bbc7af00af91a8a57d6d296b12114a8c229eba7cL2032-R2107) [[20]](diffhunk://#diff-0c8a2fab8eac2442c77c71d71f1ecc55882b5a4ab0144f58fbd8d02ff42a3272L2102-R2109) [[21]](diffhunk://#diff-0c8a2fab8eac2442c77c71d71f1ecc55882b5a4ab0144f58fbd8d02ff42a3272L2592-R2607) [[22]](diffhunk://#diff-d76fde92a961aef9b0f996492a5e45f57057c70ec4351246bc0d2d970df2f91eL427-R433) [[23]](diffhunk://#diff-d13d143c911dbbf1f591277baf0060951aaa361914c6faba9952eede979aee1cL1199-R1208)

**Documentation Updates**

* Added a new section to `AGENTS.md` explaining the preferred artifact I/O strategy: direct reads for deterministic paths, minimal directory listings, and guidance for handling missing files and errors.
* Updated `NEWS.md` to document the new artifact reading strategy and summarize related bug fixes and behavioral changes.

**Bug Fixes and Behavioral Changes**

* Ensured that local CSV read-time metadata and I/O failures propagate as errors instead of returning empty or partial results.
* Improved handling of empty or missing artifacts, preserving valid empty files and optional missing artifacts as before.
* Avoided repeated validation and redundant downloads/reads for known-path workflows.

**Version Bump**

* Incremented the package version from `0.7.0.9004` to `0.7.0.9005` in `DESCRIPTION`.

These changes collectively improve the efficiency, reliability, and clarity of artifact management in the codebase.